### PR TITLE
BUG FIX: Fix skill tree node rendering and smooth zoom

### DIFF
--- a/src/generated/resources/data/mmorpg/recipes/destroy_output_exp.json
+++ b/src/generated/resources/data/mmorpg/recipes/destroy_output_exp.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "minecraft:anvil"
+    },
+    "X": {
+      "item": "minecraft:iron_nugget"
+    }
+  },
+  "pattern": [
+    "XXX",
+    "XCX",
+    "XXX"
+  ],
+  "result": {
+    "item": "mmorpg:destroy_output_exp"
+  },
+  "show_notification": true
+}

--- a/src/main/java/com/robertx22/age_of_exile/config/forge/ClientConfigs.java
+++ b/src/main/java/com/robertx22/age_of_exile/config/forge/ClientConfigs.java
@@ -37,6 +37,7 @@ public class ClientConfigs {
         GUI_POSITION = b.defineEnum("GUI_POSITION", GuiPosition.TOP_LEFT);
         ITEM_RARITY_BACKGROUND_TYPE = b.defineEnum("ITEM_RARITY_BACKGROUND_TYPE", GlintType.FULL);
         PLAYER_GUI_TYPE = b.defineEnum("PLAYER_GUI_TYPE", PlayerGUIs.RPG);
+        SKILL_TREE_ZOOM_SPEED = b.defineInRange("SKILL_TREE_ZOOM_SPEED", 0.15D, 0.000001D, 1D);
 
         b.pop();
     }
@@ -56,6 +57,7 @@ public class ClientConfigs {
     public ForgeConfigSpec.EnumValue<PlayerGUIs> PLAYER_GUI_TYPE;
     public ForgeConfigSpec.DoubleValue ITEM_RARITY_OPACITY;
     public ForgeConfigSpec.DoubleValue HEALTH_BAR_GUI_SCALE;
+    public ForgeConfigSpec.DoubleValue SKILL_TREE_ZOOM_SPEED;
 
     public int REMOVE_EMPTY_TOOLTIP_LINES_IF_MORE_THAN_X_LINES = 35;
 

--- a/src/main/java/com/robertx22/age_of_exile/gui/screens/skill_tree/SkillTreeScreen.java
+++ b/src/main/java/com/robertx22/age_of_exile/gui/screens/skill_tree/SkillTreeScreen.java
@@ -344,6 +344,7 @@ public abstract class SkillTreeScreen extends BaseScreen implements INamedScreen
 
 
     public float zoom = 0.3F;
+    public float targetZoom = zoom;
 
 
     @Override
@@ -365,18 +366,19 @@ public abstract class SkillTreeScreen extends BaseScreen implements INamedScreen
 
     private void resetZoom() {
         zoom = 1;
+        targetZoom = zoom;
     }
 
     @Override
     public boolean mouseScrolled(double mouseX, double mouseY, double scroll) {
         if (scroll < 0) {
-            zoom -= 0.1F;
+            targetZoom -= 0.1F;
         }
         if (scroll > 0) {
-            zoom += 0.1F;
+            targetZoom += 0.1F;
         }
 
-        this.zoom = Mth.clamp(zoom, 0.08F, 1);
+        this.targetZoom = Mth.clamp(targetZoom, 0.08F, 1);
 
         return true;
     }
@@ -403,7 +405,7 @@ public abstract class SkillTreeScreen extends BaseScreen implements INamedScreen
         mouseRecentlyClickedTicks--;
 
         renderBackgroundDirt(gui, this, 0);
-
+        zoom = Mth.lerp(0.2F, zoom, targetZoom);
         gui.pose().scale(zoom, zoom, zoom);
 
         try {

--- a/src/main/java/com/robertx22/age_of_exile/gui/screens/skill_tree/SkillTreeScreen.java
+++ b/src/main/java/com/robertx22/age_of_exile/gui/screens/skill_tree/SkillTreeScreen.java
@@ -6,6 +6,7 @@ import com.mojang.blaze3d.vertex.BufferBuilder;
 import com.mojang.blaze3d.vertex.Tesselator;
 import com.mojang.math.Axis;
 import com.robertx22.age_of_exile.capability.player.PlayerData;
+import com.robertx22.age_of_exile.config.forge.ClientConfigs;
 import com.robertx22.age_of_exile.database.data.perks.Perk;
 import com.robertx22.age_of_exile.database.data.stats.types.UnknownStat;
 import com.robertx22.age_of_exile.database.data.talent_tree.TalentTree;
@@ -405,7 +406,7 @@ public abstract class SkillTreeScreen extends BaseScreen implements INamedScreen
         mouseRecentlyClickedTicks--;
 
         renderBackgroundDirt(gui, this, 0);
-        zoom = Mth.lerp(0.2F, zoom, targetZoom);
+        zoom = Mth.lerp(ClientConfigs.getConfig().SKILL_TREE_ZOOM_SPEED.get().floatValue(), zoom, targetZoom);
         gui.pose().scale(zoom, zoom, zoom);
 
         try {

--- a/src/main/java/com/robertx22/age_of_exile/gui/screens/skill_tree/buttons/PerkButton.java
+++ b/src/main/java/com/robertx22/age_of_exile/gui/screens/skill_tree/buttons/PerkButton.java
@@ -21,6 +21,7 @@ import net.minecraft.client.gui.components.Tooltip;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.Mth;
 
 import java.util.List;
 
@@ -64,8 +65,7 @@ public class PerkButton extends ImageButton {
     public boolean isInside(int x, int y) {
 
         float scale = 2 - screen.zoom;
-
-        return GuiUtils.isInRect((int) (this.getX()), (int) (this.getY()), (int) (width * scale), (int) (height * scale), x, y);
+        return GuiUtils.isInRect((int) (this.getX() - ((width/4) * scale)), (int) (this.getY() - ((height/4) * scale)), (int) (width * scale), (int) (height * scale), x, y);
     }
 
 
@@ -141,9 +141,9 @@ public class PerkButton extends ImageButton {
         if (posMulti > 1.5F) {
             posMulti = 1.5F;
         }
-
+        float zoomOffset = Mth.lerp(screen.zoom, 0.04f, 0f);
+        gui.pose().translate(-zoomOffset, -zoomOffset, 0);
         gui.pose().scale(scale, scale, scale);
-
         PerkStatus status = playerData.talents.getStatus(Minecraft.getInstance().player, school, point);
 
 

--- a/src/main/java/com/robertx22/age_of_exile/gui/screens/skill_tree/buttons/PerkButton.java
+++ b/src/main/java/com/robertx22/age_of_exile/gui/screens/skill_tree/buttons/PerkButton.java
@@ -123,11 +123,13 @@ public class PerkButton extends ImageButton {
     }
 
     int xPos(int offset, float multi) {
-        return (int) ((this.getX()) * multi) + offset;
+        float scale = 2 - screen.zoom;
+        return (int) ((this.getX() - ((width/6) * scale)) * multi) + offset;
     }
 
     int yPos(int offset, float multi) {
-        return (int) ((this.getY()) * multi) + offset;
+        float scale = 2 - screen.zoom;
+        return (int) ((this.getY() - ((height/6) * scale)) * multi) + offset;
     }
 
     @Override
@@ -141,9 +143,11 @@ public class PerkButton extends ImageButton {
         if (posMulti > 1.5F) {
             posMulti = 1.5F;
         }
-        float zoomOffset = Mth.lerp(screen.zoom, 0.04f, 0f);
-        gui.pose().translate(-zoomOffset, -zoomOffset, 0);
+        float zoomOffset = Mth.lerp(screen.zoom, 0.f, 0.04f);
+        gui.pose().translate(width/2f, height/2f, 0);
         gui.pose().scale(scale, scale, scale);
+        float inverse = 1F / scale;
+        gui.pose().translate((-(width - zoomOffset)/2f) * inverse, (-(height - zoomOffset)/2f) * inverse, 0);
         PerkStatus status = playerData.talents.getStatus(Minecraft.getInstance().player, school, point);
 
 


### PR DESCRIPTION
Fixed skill nodes in the skill tree rendering slightly offset when zoomed out.
Also smoothed out the zoom as a small QoL change.