### PR TITLE
Adding a new player config for dropping chest loot on the ground in maps

### DIFF
--- a/src/main/java/com/robertx22/age_of_exile/capability/player/data/DeathFavorData.java
+++ b/src/main/java/com/robertx22/age_of_exile/capability/player/data/DeathFavorData.java
@@ -5,12 +5,15 @@ import com.robertx22.age_of_exile.database.data.rarities.GearRarity;
 import com.robertx22.age_of_exile.database.registry.ExileDB;
 import com.robertx22.age_of_exile.mmorpg.SlashRef;
 import com.robertx22.age_of_exile.uncommon.MathHelper;
+import com.robertx22.age_of_exile.uncommon.datasaving.Load;
 import com.robertx22.age_of_exile.uncommon.interfaces.data_items.IRarity;
 import com.robertx22.age_of_exile.uncommon.localization.Chats;
 import com.robertx22.age_of_exile.uncommon.localization.Gui;
+import com.robertx22.age_of_exile.uncommon.utilityclasses.OnScreenMessageUtils;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.player.Player;
 
 import java.util.ArrayList;
@@ -48,8 +51,11 @@ public class DeathFavorData {
     }
 
     public void onLootChest(Player p) {
-        set(p, favor + ServerContainer.get().FAVOR_CHEST_GAIN.get().floatValue());
 
+        float favorGain = ServerContainer.get().FAVOR_CHEST_GAIN.get().floatValue();
+
+        set(p, favor + favorGain);
+        OnScreenMessageUtils.actionBar((ServerPlayer) p, Component.literal("+" + favorGain + " ").append(Component.literal("Favor (" + favor + ")")).withStyle(ChatFormatting.GREEN));
         //  Load.player(p).prophecy.favor += ServerContainer.get().FAVOR_CHEST_GAIN.get();
     }
 

--- a/src/main/java/com/robertx22/age_of_exile/capability/player/data/PlayerConfigData.java
+++ b/src/main/java/com/robertx22/age_of_exile/capability/player/data/PlayerConfigData.java
@@ -27,7 +27,9 @@ public class PlayerConfigData {
         AUTO_PVE("auto_pve", Words.AUTOMATIC_PVE, false),
         AGGRESSIVE_SUMMONS("aggressive_summons", Words.AGGRESIVE_SUMMONS, false),
         STAT_ORDER_TEST("stat_order_test", Words.STAT_ORDER_TEST, true),
-        DAMAGE_CONFLICT_MSG("damage_conflict_check", Words.DMG_CONFLICT_CHECK, true);
+        DAMAGE_CONFLICT_MSG("damage_conflict_check", Words.DMG_CONFLICT_CHECK, true),
+        DROP_MAP_CHEST_CONTENTS_ON_GROUND("drop_map_chest_contents_on_ground", Words.DROP_MAP_CHEST_CONTENTS_ON_GROUND, false);
+
         public String id;
         public Words word;
         public boolean isDebug;

--- a/src/main/java/com/robertx22/age_of_exile/event_hooks/my_events/OnLootChestEvent.java
+++ b/src/main/java/com/robertx22/age_of_exile/event_hooks/my_events/OnLootChestEvent.java
@@ -1,14 +1,22 @@
 package com.robertx22.age_of_exile.event_hooks.my_events;
 
 import com.google.common.collect.Lists;
+import com.robertx22.age_of_exile.capability.player.data.PlayerConfigData;
+import com.robertx22.age_of_exile.database.registry.ExileDB;
 import com.robertx22.age_of_exile.loot.LootInfo;
 import com.robertx22.age_of_exile.loot.MasterLootGen;
 import com.robertx22.age_of_exile.uncommon.datasaving.Load;
+import com.robertx22.age_of_exile.uncommon.utilityclasses.OnScreenMessageUtils;
+import com.robertx22.age_of_exile.uncommon.utilityclasses.WorldUtils;
 import com.robertx22.library_of_exile.events.base.EventConsumer;
 import com.robertx22.library_of_exile.events.base.ExileEvents;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.Container;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
 
 import java.util.Collections;
 import java.util.List;
@@ -23,8 +31,21 @@ public class OnLootChestEvent extends EventConsumer<ExileEvents.OnChestLooted> {
 
         LootInfo info = LootInfo.ofChestLoot(player, event.pos);
 
+        Load.player(player).favor.onLootChest(player);
 
         List<ItemStack> items = MasterLootGen.generateLoot(info);
+
+        if(Load.player(player).config.isConfigEnabled(PlayerConfigData.Config.DROP_MAP_CHEST_CONTENTS_ON_GROUND) && WorldUtils.isMapWorldClass(player.level())) {
+            for(ItemStack item : items) {
+                player.spawnAtLocation(item, 1F);
+            }
+
+            for(int i=0; i<event.inventory.getContainerSize(); i++) {
+                event.inventory.setItem(i, ItemStack.EMPTY);
+            }
+
+            return;
+        }
 
         List<Integer> list1 = mygetEmptySlotsRandomized(event.inventory, new Random());
 
@@ -32,7 +53,6 @@ public class OnLootChestEvent extends EventConsumer<ExileEvents.OnChestLooted> {
             return;
         }
 
-        Load.player(player).favor.onLootChest(player);
 
         for (int i = 0; i < items.size(); i++) {
             if (i < list1.size()) {

--- a/src/main/java/com/robertx22/age_of_exile/uncommon/localization/Words.java
+++ b/src/main/java/com/robertx22/age_of_exile/uncommon/localization/Words.java
@@ -50,6 +50,7 @@ public enum Words implements IAutoLocName {
     STAT_ORDER_TEST("Stat Order Test [Debug Option]\nThis runs a few tests when you attack something to be sure the stats are working in correct order and sends warning message if they don't. Only use when debugging stats. For example, crit chance should work before crit damage stat"),
     DMG_CONFLICT_CHECK("Mod Conflict Check [Debug Option]\n\nChecks if Mine and Slash damage has been overrided by another mod.\nSends a message to player if there's a problem.\n THIS IS A DEBUG OPTION"),
     AGGRESIVE_SUMMONS("Aggressive Summons\n\nYour summons will now attack anything they guess is an enemy, and on longer need guidance from you.\n\nYou need to Re-Summon your minions for this to take effect"),
+    DROP_MAP_CHEST_CONTENTS_ON_GROUND("Drop Map Chest Contents When Looted\n\nWhen you loot chests in maps, should they drop their contents on the ground automatically? \n\nThis is helpful if you use the Master Backpack or other loot filtering mods like Sophisticated Backpacks."),
 
     WHILE_UNDER_AURA("While Under Effect of %1$s:"),
     CURSE_OFFERS("Curse Offers:"),

--- a/src/main/resources/assets/mmorpg/lang/en_us.json
+++ b/src/main/resources/assets/mmorpg/lang/en_us.json
@@ -2554,6 +2554,7 @@
 	"mmorpg.word.dmgmultiinfo": "Damage Multiplier. This is a multiplicative damage source",
 	"mmorpg.word.downgradeaffix": "Downgrades an affix",
 	"mmorpg.word.drag_no_work_creative": "Drag and Drop Interactions Do-NOT work in Creative Mode!",
+	"mmorpg.word.drop_map_chest_contents_on_ground": "Drop Map Chest Contents When Looted\n\nWhen you loot chests in maps, should they drop their contents on the ground automatically? \n\nThis is helpful if you use the Master Backpack or other loot filtering mods like Sophisticated Backpacks.",
 	"mmorpg.word.dungeonkey": "Dungeon Key",
 	"mmorpg.word.easy": "Easy",
 	"mmorpg.word.effects": "Effects:",


### PR DESCRIPTION
This **should** make mapping more efficient in cases where you have an item magnet and some auto loot sorting options available to you. In the CTE2 modpack, we've got `Sophisticated Backpacks` and item magnets, which makes this a LOT faster than manually dropping everything in the chest, which is the current workaround for this.

Since it's configurable, if you don't need this, don't use it!

Here's an image of what the config "Feature" looks like:
![image](https://github.com/RobertSkalko/Mine-And-Slash-Rework/assets/5777539/5e20bf26-977c-415d-a398-d8a90bb762a0)
