### PR TITLE
optimize talent tree

### DIFF
--- a/src/main/java/com/robertx22/mine_and_slash/characters/reworked_gui/ToonScreen.java
+++ b/src/main/java/com/robertx22/mine_and_slash/characters/reworked_gui/ToonScreen.java
@@ -100,6 +100,7 @@ public class ToonScreen extends Screen implements INamedScreen {
 
     @Override
     public boolean charTyped(char pCodePoint, int pModifiers) {
+        this.searchBox.setFocused(true);
         return this.searchBox.charTyped(pCodePoint, pModifiers);
     }
 

--- a/src/main/java/com/robertx22/mine_and_slash/gui/screens/character_screen/MainHubScreen.java
+++ b/src/main/java/com/robertx22/mine_and_slash/gui/screens/character_screen/MainHubScreen.java
@@ -461,6 +461,11 @@ public class MainHubScreen extends BaseScreen implements INamedScreen {
 
         }
 
+        @Override
+        public void onRelease(double pMouseX, double pMouseY) {
+            this.setFocused(false);
+        }
+
     }
 
 

--- a/src/main/java/com/robertx22/mine_and_slash/gui/screens/skill_tree/BufferInfo.java
+++ b/src/main/java/com/robertx22/mine_and_slash/gui/screens/skill_tree/BufferInfo.java
@@ -1,0 +1,56 @@
+package com.robertx22.mine_and_slash.gui.screens.skill_tree;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import org.joml.Matrix4f;
+
+public record BufferInfo(float pX1, float pX2, float pY1, float pY2, float pBlitOffset, float pMinU, float pMaxU, float pMinV,
+                         float pMaxV, Matrix4f matrix4f, RenderInfo renderInfo) {
+
+    public static BufferInfo of(float pX, float pY, float pBlitOffset, int pUOffset, int pVOffset, int pUWidth, int pVHeight, Matrix4f matrix4f) {
+        return of(pX, pY, pBlitOffset, (float) pUOffset, (float) pVOffset, pUWidth, pVHeight, 256, 256, matrix4f);
+    }
+
+    public static BufferInfo of(float pX, float pY, int pUOffset, int pVOffset, int pUWidth, int pVHeight, Matrix4f matrix4f) {
+        return of(pX, pY, 0, (float) pUOffset, (float) pVOffset, pUWidth, pVHeight, 256, 256, matrix4f);
+    }
+
+    public static BufferInfo of(float pX, float pY, float pBlitOffset, float pUOffset, float pVOffset, int pUWidth, int pVHeight, int pTextureWidth, int pTextureHeight, Matrix4f matrix4f) {
+        return of(pX, pX + pUWidth, pY, pY + pVHeight, pBlitOffset, pUWidth, pVHeight, pUOffset, pVOffset, pTextureWidth, pTextureHeight, matrix4f);
+    }
+
+    public static BufferInfo of(float pX, float pY, int pWidth, int pHeight, float pUOffset, float pVOffset, int pUWidth, int pVHeight, int pTextureWidth, int pTextureHeight, Matrix4f matrix4f) {
+        return of(pX, pX + pWidth, pY, pY + pHeight, 0, pUWidth, pVHeight, pUOffset, pVOffset, pTextureWidth, pTextureHeight, matrix4f);
+    }
+
+    public static BufferInfo of(float pX, float pY, int pWidth, int pHeight, float pBlitOffset, float pUOffset, float pVOffset, int pUWidth, int pVHeight, int pTextureWidth, int pTextureHeight, Matrix4f matrix4f) {
+        return of(pX, pX + pWidth, pY, pY + pHeight, pBlitOffset, pUWidth, pVHeight, pUOffset, pVOffset, pTextureWidth, pTextureHeight, matrix4f);
+    }
+
+
+
+    public static BufferInfo of(float pX, float pY, float pUOffset, float pVOffset, int pWidth, int pHeight, int pTextureWidth, int pTextureHeight, Matrix4f matrix4f) {
+        return of(pX, pY, pWidth, pHeight, pUOffset, pVOffset, pWidth, pHeight, pTextureWidth, pTextureHeight, matrix4f);
+    }
+
+    public static BufferInfo of(float pX1, float pX2, float pY1, float pY2, float pBlitOffset, int pUWidth, int pVHeight, float pUOffset, float pVOffset, int pTextureWidth, int pTextureHeight, Matrix4f matrix4f) {
+        return new BufferInfo(pX1, pX2, pY1, pY2, pBlitOffset, (pUOffset + 0.0F) / (float)pTextureWidth, (pUOffset + (float)pUWidth) / (float)pTextureWidth, (pVOffset + 0.0F) / (float)pTextureHeight, (pVOffset + (float)pVHeight) / (float)pTextureHeight, matrix4f, new RenderInfo(1.0f));
+    }
+
+    public BufferInfo withRenderInfo(RenderInfo renderInfo){
+        return new BufferInfo(pX1, pX2, pY1, pY2, pBlitOffset, this.pMinU, this.pMaxU, this.pMinV, this.pMaxV, this.matrix4f, renderInfo);
+    }
+    
+    public void upload(VertexConsumer consumer){
+        final int light = 0xF000F0;
+        float opacity = Math.min(this.renderInfo().opacity, 1.0f);
+        consumer.vertex(matrix4f, pX1, pY1, pBlitOffset).color(1.0f, 1.0f, 1.0f, opacity).uv(pMinU, pMinV).uv2(light).endVertex();
+        consumer.vertex(matrix4f, pX1, pY2, pBlitOffset).color(1.0f, 1.0f, 1.0f, opacity).uv(pMinU, pMaxV).uv2(light).endVertex();
+        consumer.vertex(matrix4f, pX2, pY2, pBlitOffset).color(1.0f, 1.0f, 1.0f, opacity).uv(pMaxU, pMaxV).uv2(light).endVertex();
+        consumer.vertex(matrix4f, pX2, pY1, pBlitOffset).color(1.0f, 1.0f, 1.0f, opacity).uv(pMaxU, pMinV).uv2(light).endVertex();
+    }
+
+    public record RenderInfo(float opacity){
+
+    }
+}

--- a/src/main/java/com/robertx22/mine_and_slash/gui/screens/skill_tree/BufferInfo.java
+++ b/src/main/java/com/robertx22/mine_and_slash/gui/screens/skill_tree/BufferInfo.java
@@ -34,7 +34,7 @@ public record BufferInfo(float pX1, float pX2, float pY1, float pY2, float pBlit
     }
 
     public static BufferInfo of(float pX1, float pX2, float pY1, float pY2, float pBlitOffset, int pUWidth, int pVHeight, float pUOffset, float pVOffset, int pTextureWidth, int pTextureHeight, Matrix4f matrix4f) {
-        return new BufferInfo(pX1, pX2, pY1, pY2, pBlitOffset, (pUOffset + 0.0F) / (float)pTextureWidth, (pUOffset + (float)pUWidth) / (float)pTextureWidth, (pVOffset + 0.0F) / (float)pTextureHeight, (pVOffset + (float)pVHeight) / (float)pTextureHeight, matrix4f, new RenderInfo(1.0f));
+        return new BufferInfo(pX1, pX2, pY1, pY2, pBlitOffset, (pUOffset + 0.0F) / (float)pTextureWidth, (pUOffset + (float)pUWidth) / (float)pTextureWidth, (pVOffset + 0.0F) / (float)pTextureHeight, (pVOffset + (float)pVHeight) / (float)pTextureHeight, new Matrix4f(matrix4f), new RenderInfo(1.0f));
     }
 
     public BufferInfo withRenderInfo(RenderInfo renderInfo){

--- a/src/main/java/com/robertx22/mine_and_slash/gui/screens/skill_tree/SkillTreeRenderType.java
+++ b/src/main/java/com/robertx22/mine_and_slash/gui/screens/skill_tree/SkillTreeRenderType.java
@@ -1,0 +1,35 @@
+package com.robertx22.mine_and_slash.gui.screens.skill_tree;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.DefaultVertexFormat;
+import com.mojang.blaze3d.vertex.VertexFormat;
+import com.robertx22.mine_and_slash.a_libraries.neat.NeatRenderType;
+import com.robertx22.mine_and_slash.mixins.AccessorRenderType;
+import com.robertx22.mine_and_slash.mmorpg.SlashRef;
+import net.minecraft.client.renderer.RenderStateShard;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.resources.ResourceLocation;
+
+
+public class SkillTreeRenderType extends RenderStateShard {
+
+    public SkillTreeRenderType(String pName, Runnable pSetupState, Runnable pClearState) {
+        super(pName, pSetupState, pClearState);
+    }
+
+    public static RenderType CONNECTION = getSkillTreeRenderType("connection", SlashRef.id("textures/gui/skill_tree/skill_connection.png"));
+
+    private static final TransparencyStateShard blend = new TransparencyStateShard("boring_blend", RenderSystem::enableBlend, RenderSystem::disableBlend);
+
+
+
+    public static RenderType getSkillTreeRenderType(String name, ResourceLocation texture) {
+        RenderType.CompositeState renderTypeState = RenderType.CompositeState.builder()
+                .setShaderState(RenderStateShard.POSITION_COLOR_TEX_LIGHTMAP_SHADER)
+                .setTextureState(new TextureStateShard(texture, false, false))
+                .setTransparencyState(new TransparencyStateShard("boring_blend", RenderSystem::enableBlend, RenderSystem::disableBlend))
+                .setLightmapState(LIGHTMAP)
+                .createCompositeState(false);
+        return AccessorRenderType.neat_create(name, DefaultVertexFormat.POSITION_COLOR_TEX_LIGHTMAP, VertexFormat.Mode.QUADS, 1536, false, true, renderTypeState);
+    }
+}

--- a/src/main/java/com/robertx22/mine_and_slash/gui/screens/skill_tree/SkillTreeScreen.java
+++ b/src/main/java/com/robertx22/mine_and_slash/gui/screens/skill_tree/SkillTreeScreen.java
@@ -1,12 +1,14 @@
 package com.robertx22.mine_and_slash.gui.screens.skill_tree;
 
+import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Sets;
+import com.mojang.blaze3d.platform.GlStateManager;
 import com.mojang.blaze3d.systems.RenderSystem;
-import com.mojang.blaze3d.vertex.BufferBuilder;
-import com.mojang.blaze3d.vertex.Tesselator;
+import com.mojang.blaze3d.vertex.*;
 import com.mojang.math.Axis;
 import com.robertx22.library_of_exile.utils.Watch;
 import com.robertx22.mine_and_slash.capability.player.PlayerData;
+import com.robertx22.mine_and_slash.capability.player.data.PlayerBuffData;
 import com.robertx22.mine_and_slash.config.forge.ClientConfigs;
 import com.robertx22.mine_and_slash.database.data.perks.Perk;
 import com.robertx22.mine_and_slash.database.data.stats.types.UnknownStat;
@@ -18,6 +20,7 @@ import com.robertx22.mine_and_slash.gui.bases.IAlertScreen;
 import com.robertx22.mine_and_slash.gui.bases.INamedScreen;
 import com.robertx22.mine_and_slash.gui.screens.skill_tree.buttons.PerkButton;
 import com.robertx22.mine_and_slash.gui.screens.skill_tree.buttons.PerkConnectionRender;
+import com.robertx22.mine_and_slash.gui.screens.skill_tree.buttons.PerkPointPair;
 import com.robertx22.mine_and_slash.gui.screens.skill_tree.buttons.PerkScreenContext;
 import com.robertx22.mine_and_slash.mmorpg.MMORPG;
 import com.robertx22.mine_and_slash.mmorpg.SlashRef;
@@ -25,6 +28,7 @@ import com.robertx22.mine_and_slash.saveclasses.PointData;
 import com.robertx22.mine_and_slash.uncommon.datasaving.Load;
 import com.robertx22.mine_and_slash.uncommon.localization.Gui;
 import com.robertx22.mine_and_slash.uncommon.utilityclasses.ClientOnly;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
@@ -32,10 +36,15 @@ import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.components.EditBox;
 import net.minecraft.client.gui.components.Renderable;
 import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.renderer.GameRenderer;
+import net.minecraft.client.renderer.RenderType;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Mth;
+import org.apache.commons.lang3.tuple.Pair;
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL11C;
 
 import java.awt.*;
 import java.util.*;
@@ -48,14 +57,15 @@ public abstract class SkillTreeScreen extends BaseScreen implements INamedScreen
     public HashSet<PerkConnectionRender> buttonConnections = new HashSet<>();
 
     static ResourceLocation CON = SlashRef.id("textures/gui/skill_tree/skill_connection.png");
+    public VertexContainer vertexContainer = new VertexContainer();
 
 
-    private void renderConnection(GuiGraphics graphics, PerkConnectionRender connection) {
+    private void renderConnection(GuiGraphics graphics, PerkConnectionRender renderer, VertexConsumer buffer) {
 
         graphics.pose().pushPose();
-
-        PerkButton button1 = pointPerkButtonMap.get(connection.perk1);
-        PerkButton button2 = pointPerkButtonMap.get(connection.perk2);
+        PerkPointPair pair = renderer.pair();
+        PerkButton button1 = pointPerkButtonMap.get(pair.data1());
+        PerkButton button2 = pointPerkButtonMap.get(pair.data2());
 
         PerkScreenContext ctx = new PerkScreenContext(this);
 
@@ -79,17 +89,21 @@ public abstract class SkillTreeScreen extends BaseScreen implements INamedScreen
 
         int off = 0;
 
-        if (connection.connection == Perk.Connection.LINKED) {
+        if (renderer.connection() == Perk.Connection.LINKED) {
             off = 0;
         }
-        if (connection.connection == Perk.Connection.POSSIBLE) {
+        if (renderer.connection() == Perk.Connection.POSSIBLE) {
             off = 6;
         }
-        if (connection.connection == Perk.Connection.BLOCKED) {
-            off = 6 + 5;
+        if (renderer.connection() == Perk.Connection.BLOCKED) {
+            off = (6 + 5);
         }
 
-        graphics.blit(CON, 0, -3, length, 6, 0, off, length, 6, 50, 16);
+        HashMultimap<ResourceLocation, BufferInfo> map = this.vertexContainer.map;
+        map.put(SlashRef.id("textures/gui/skill_tree/skill_connection.png"), BufferInfo.of(0, -3,  length, 6, -5, (float) 0, off, length, 6, 50, 16, graphics.pose().last().pose()));
+
+
+        //graphics.blit(CON, 0, -3, length, 6, 0, off, length, 6, 50, 16);
 
         graphics.pose().popPose();
     }
@@ -153,10 +167,15 @@ public abstract class SkillTreeScreen extends BaseScreen implements INamedScreen
 
 
     private void renderConnections(GuiGraphics gui) {
-
+        RenderSystem.setShaderTexture(0, SlashRef.id("textures/gui/skill_tree/skill_connection.png"));
+        RenderSystem.setShader(GameRenderer::getPositionTexShader);
+        BufferBuilder bufferbuilder = Tesselator.getInstance().getBuilder();
+        bufferbuilder.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_TEX);
         for (PerkConnectionRender con : this.buttonConnections) {
-            this.renderConnection(gui, con);
+            this.renderConnection(gui, con, bufferbuilder);
         }
+
+        BufferUploader.drawWithShader(bufferbuilder.end());
     }
 
 
@@ -210,6 +229,12 @@ public abstract class SkillTreeScreen extends BaseScreen implements INamedScreen
     }
 
     @Override
+    public boolean charTyped(char pCodePoint, int pModifiers) {
+        SEARCH.setFocused(true);
+        return super.charTyped(pCodePoint, pModifiers);
+    }
+
+    @Override
     public void tick() {
         SEARCH.tick();
     }
@@ -242,37 +267,28 @@ public abstract class SkillTreeScreen extends BaseScreen implements INamedScreen
 
     private void addConnections() {
 
-        buttonConnections = new HashSet<>();
+        buttonConnections = new HashSet<>(2000);
 
-        HashSet<PointData> def = new HashSet();
-
-        Set<Set<PointData>> cons = new HashSet<>();
         var data = Load.player(ClientOnly.getPlayer());
 
+        IntOpenHashSet integers = new IntOpenHashSet(2000);
+        children().forEach(b -> {
+            if (b instanceof PerkButton pb) {
 
-        new ArrayList<>(children()).forEach(b -> {
-            if (b instanceof PerkButton) {
-                PerkButton pb = (PerkButton) b;
-
-                Set<PointData> connections = this.school.calcData.connections.getOrDefault(pb.point, def);
+                Set<PointData> connections = this.school.calcData.connections.getOrDefault(pb.point, Collections.EMPTY_SET);
 
                 for (PointData p : connections) {
 
-                    if (cons.stream().anyMatch(x -> x.contains(p) && x.contains(pb.point))) {
-                        continue;
-                    }
-
-                    cons.add(Sets.newHashSet(p, pb.point));
-
                     PerkButton sb = this.pointPerkButtonMap.get(p);
+                    PerkPointPair pair = new PerkPointPair(pb.point, sb.point);
+                    if (!integers.contains(pair.hashCode())) {
 
-                    if (sb == null) {
-                        continue;
+                        var con = data.talents.getConnection(this.school, sb.point, pb.point);
+                        var result = new PerkConnectionRender(pair, con);
+                        buttonConnections.add(result);
+                        integers.add(pair.hashCode());
                     }
 
-                    var con = data.talents.getConnection(school, sb.point, pb.point);
-                    var result = new PerkConnectionRender(pb.point, sb.point, con);
-                    buttonConnections.add(result);
                 }
             }
 
@@ -437,7 +453,7 @@ public abstract class SkillTreeScreen extends BaseScreen implements INamedScreen
 
         renderBackgroundDirt(gui, this, 0);
         zoom = Mth.lerp(ClientConfigs.getConfig().SKILL_TREE_ZOOM_SPEED.get().floatValue(), zoom, targetZoom);
-
+        renderPanels(gui);
         gui.pose().scale(zoom, zoom, zoom);
 
         try {
@@ -462,7 +478,6 @@ public abstract class SkillTreeScreen extends BaseScreen implements INamedScreen
 
             this.renderConnections(gui);
 
-
             ticks++;
 
             if (mouseRecentlyClickedTicks > 1) {
@@ -472,7 +487,20 @@ public abstract class SkillTreeScreen extends BaseScreen implements INamedScreen
 
 
             super.render(gui, x, y, ticks);
+            //Watch watch1 = new Watch();
+            for (Map.Entry<ResourceLocation, Collection<BufferInfo>> entry : this.vertexContainer.map.asMap().entrySet()) {
+                ResourceLocation key = entry.getKey();
+                RenderType skillTreeRenderType = SkillTreeRenderType.getSkillTreeRenderType(key.toString(), key);
+                VertexConsumer buffer = gui.bufferSource().getBuffer(skillTreeRenderType);
 
+                for (BufferInfo bufferInfo : entry.getValue()) {
+                    bufferInfo.upload(buffer);
+                }
+
+            }
+
+            this.vertexContainer.refresh();
+            //System.out.println(watch1.getPrint());
             this.tick_count++;
 
         } catch (Exception e) {
@@ -482,7 +510,7 @@ public abstract class SkillTreeScreen extends BaseScreen implements INamedScreen
 
         gui.pose().scale(1F / zoom, 1F / zoom, 1F / zoom);
 
-        renderPanels(gui);
+
 
         this.msstring = watch.getPrint();
 
@@ -497,17 +525,12 @@ public abstract class SkillTreeScreen extends BaseScreen implements INamedScreen
     public static void renderBackgroundDirt(GuiGraphics gui, Screen screen, int vOffset) {
         //copied from Screen
 
-        Tesselator tessellator = Tesselator.getInstance();
-        BufferBuilder bufferBuilder = tessellator.getBuilder();
-
-        RenderSystem.setShaderTexture(0, BACKGROUND);
-
         Minecraft mc = Minecraft.getInstance();
 
         // todo test
         //gui.setColor(0.25F, 0.25F, 0.25F, 1.0F);
         int i = 32;
-        gui.blit(BACKGROUND, 0, 0, 0, 0.0F, 0.0F, mc.screen.width, mc.screen.height, 32, 32);
+        gui.blit(BACKGROUND, 0, 0, -10, 0.0F, 0.0F, mc.screen.width, mc.screen.height, 32, 32);
         //gui.setColor(1.0F, 1.0F, 1.0F, 1.0F);
 
     }
@@ -517,18 +540,19 @@ public abstract class SkillTreeScreen extends BaseScreen implements INamedScreen
 
         Minecraft mc = Minecraft.getInstance();
 
+
+
         RenderSystem.enableDepthTest();
-
-
+        RenderSystem.depthFunc(GL11.GL_ALWAYS);
         int BG_WIDTH = 256;
         int BG_HEIGHT = 22;
 
         int xp = (int) (mc.getWindow().getGuiScaledWidth() / 2F - BG_WIDTH / 2F);
         int yp = 0;
 
-        gui.blit(BIG_PANEL, xp, yp, 0, 0, BG_WIDTH, BG_HEIGHT);
+        gui.blit(BIG_PANEL, xp, yp,0, 0, BG_WIDTH, BG_HEIGHT);
 
-        RenderSystem.enableDepthTest();
+        RenderSystem.depthFunc(GL11.GL_LEQUAL);
 
         int savedx = xp;
         int savedy = yp;
@@ -557,6 +581,8 @@ public abstract class SkillTreeScreen extends BaseScreen implements INamedScreen
             MutableComponent debug = Component.literal("Widgets: " + this.children().size() + " - " + msstring);
             gui.drawString(mc.font, debug, savedx + 277, yx, ChatFormatting.GREEN.getColor());
         }
+
+
     }
 
 }

--- a/src/main/java/com/robertx22/mine_and_slash/gui/screens/skill_tree/SkillTreeScreen.java
+++ b/src/main/java/com/robertx22/mine_and_slash/gui/screens/skill_tree/SkillTreeScreen.java
@@ -60,7 +60,7 @@ public abstract class SkillTreeScreen extends BaseScreen implements INamedScreen
     public VertexContainer vertexContainer = new VertexContainer();
 
 
-    private void renderConnection(GuiGraphics graphics, PerkConnectionRender renderer, VertexConsumer buffer) {
+    private void renderConnection(GuiGraphics graphics, PerkConnectionRender renderer) {
 
         graphics.pose().pushPose();
         PerkPointPair pair = renderer.pair();
@@ -167,15 +167,9 @@ public abstract class SkillTreeScreen extends BaseScreen implements INamedScreen
 
 
     private void renderConnections(GuiGraphics gui) {
-        RenderSystem.setShaderTexture(0, SlashRef.id("textures/gui/skill_tree/skill_connection.png"));
-        RenderSystem.setShader(GameRenderer::getPositionTexShader);
-        BufferBuilder bufferbuilder = Tesselator.getInstance().getBuilder();
-        bufferbuilder.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_TEX);
         for (PerkConnectionRender con : this.buttonConnections) {
-            this.renderConnection(gui, con, bufferbuilder);
+            this.renderConnection(gui, con);
         }
-
-        BufferUploader.drawWithShader(bufferbuilder.end());
     }
 
 
@@ -487,20 +481,9 @@ public abstract class SkillTreeScreen extends BaseScreen implements INamedScreen
 
 
             super.render(gui, x, y, ticks);
-            //Watch watch1 = new Watch();
-            for (Map.Entry<ResourceLocation, Collection<BufferInfo>> entry : this.vertexContainer.map.asMap().entrySet()) {
-                ResourceLocation key = entry.getKey();
-                RenderType skillTreeRenderType = SkillTreeRenderType.getSkillTreeRenderType(key.toString(), key);
-                VertexConsumer buffer = gui.bufferSource().getBuffer(skillTreeRenderType);
-
-                for (BufferInfo bufferInfo : entry.getValue()) {
-                    bufferInfo.upload(buffer);
-                }
-
-            }
-
+            // draw
+            this.vertexContainer.draw(gui.bufferSource());
             this.vertexContainer.refresh();
-            //System.out.println(watch1.getPrint());
             this.tick_count++;
 
         } catch (Exception e) {

--- a/src/main/java/com/robertx22/mine_and_slash/gui/screens/skill_tree/SkillTreeScreen.java
+++ b/src/main/java/com/robertx22/mine_and_slash/gui/screens/skill_tree/SkillTreeScreen.java
@@ -231,7 +231,7 @@ public abstract class SkillTreeScreen extends BaseScreen implements INamedScreen
     @Override
     public boolean charTyped(char pCodePoint, int pModifiers) {
         SEARCH.setFocused(true);
-        return super.charTyped(pCodePoint, pModifiers);
+        return SEARCH.charTyped(pCodePoint, pModifiers);
     }
 
     @Override

--- a/src/main/java/com/robertx22/mine_and_slash/gui/screens/skill_tree/VertexContainer.java
+++ b/src/main/java/com/robertx22/mine_and_slash/gui/screens/skill_tree/VertexContainer.java
@@ -1,7 +1,13 @@
 package com.robertx22.mine_and_slash.gui.screens.skill_tree;
 
 import com.google.common.collect.HashMultimap;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderType;
 import net.minecraft.resources.ResourceLocation;
+
+import java.util.Collection;
+import java.util.Map;
 
 public class VertexContainer {
 
@@ -9,6 +15,19 @@ public class VertexContainer {
 
     public void refresh(){
         this.map = HashMultimap.create(100, 500);
+    }
+
+    public void draw(MultiBufferSource bufferSource){
+        for (Map.Entry<ResourceLocation, Collection<BufferInfo>> entry : this.map.asMap().entrySet()) {
+            ResourceLocation key = entry.getKey();
+            RenderType skillTreeRenderType = SkillTreeRenderType.getSkillTreeRenderType(key.toString(), key);
+            VertexConsumer buffer = bufferSource.getBuffer(skillTreeRenderType);
+
+            for (BufferInfo bufferInfo : entry.getValue()) {
+                bufferInfo.upload(buffer);
+            }
+
+        }
     }
 
 }

--- a/src/main/java/com/robertx22/mine_and_slash/gui/screens/skill_tree/VertexContainer.java
+++ b/src/main/java/com/robertx22/mine_and_slash/gui/screens/skill_tree/VertexContainer.java
@@ -1,0 +1,14 @@
+package com.robertx22.mine_and_slash.gui.screens.skill_tree;
+
+import com.google.common.collect.HashMultimap;
+import net.minecraft.resources.ResourceLocation;
+
+public class VertexContainer {
+
+    public HashMultimap<ResourceLocation, BufferInfo> map = HashMultimap.create(100, 500);
+
+    public void refresh(){
+        this.map = HashMultimap.create(100, 500);
+    }
+
+}

--- a/src/main/java/com/robertx22/mine_and_slash/gui/screens/skill_tree/buttons/PerkButton.java
+++ b/src/main/java/com/robertx22/mine_and_slash/gui/screens/skill_tree/buttons/PerkButton.java
@@ -2,6 +2,7 @@ package com.robertx22.mine_and_slash.gui.screens.skill_tree.buttons;
 
 import com.google.common.collect.HashMultimap;
 import com.mojang.blaze3d.systems.RenderSystem;
+import com.robertx22.library_of_exile.utils.Watch;
 import com.robertx22.mine_and_slash.capability.player.PlayerData;
 import com.robertx22.mine_and_slash.database.data.perks.Perk;
 import com.robertx22.mine_and_slash.database.data.perks.PerkStatus;
@@ -26,6 +27,7 @@ import net.minecraft.client.gui.components.Tooltip;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
+import org.apache.commons.lang3.time.StopWatch;
 import org.joml.Matrix4f;
 
 import java.util.List;
@@ -185,13 +187,8 @@ public class PerkButton extends ImageButton {
 
         var search = SkillTreeScreen.SEARCH.getValue();
 
-        boolean containsSearchStat = perk.stats.stream()
-                .anyMatch(item -> item.getStat().locName().getString().toLowerCase().contains(search.toLowerCase()));
 
-        boolean containsName = perk.locName().getString().toLowerCase().contains(search.toLowerCase());
-
-
-        float opacity = search.isEmpty() || containsSearchStat || containsName ? 1F : 0.2f;
+        float opacity;
 
         if (!search.isEmpty()) {
             if (search.equals("all")) {
@@ -200,6 +197,12 @@ public class PerkButton extends ImageButton {
                 } else {
                     opacity = 1;
                 }
+            } else {
+                boolean containsSearchStat = perk.stats.stream()
+                        .anyMatch(item -> item.getStat().locName().getString().toLowerCase().contains(search.toLowerCase()));
+
+                boolean containsName = perk.locName().getString().toLowerCase().contains(search.toLowerCase());
+                opacity = containsSearchStat || containsName ? 1F : 0.2f;
             }
         } else {
             opacity = status.getOpacity();
@@ -216,7 +219,7 @@ public class PerkButton extends ImageButton {
 
         int offcolor = (int) ((perk.getType().size - 20) / 2F);
 
-        gui.setColor(1.0F, 1.0F, 1.0F, opacity);
+        //gui.setColor(1.0F, 1.0F, 1.0F, opacity);
 
         HashMultimap<ResourceLocation, BufferInfo> container = screen.vertexContainer.map;
         var matrix4f = new Matrix4f(gui.pose().last().pose());
@@ -234,14 +237,14 @@ public class PerkButton extends ImageButton {
         }
 
 
-        gui.setColor(1.0F, 1.0F, 1.0F, MathHelper.clamp(opacity, 0, 1));
+        //gui.setColor(1.0F, 1.0F, 1.0F, MathHelper.clamp(opacity, 0, 1));
 
         container.put(perk.getIcon(), BufferInfo.of(xPos(offset, posMulti), yPos(offset, posMulti), -1, 0, 0, type.iconSize, type.iconSize, type.iconSize, type.iconSize, matrix4f).withRenderInfo(new BufferInfo.RenderInfo(opacity)));
 
 
 
         //   gui.pose().scale(1F / scale, 1F / scale, 1F / scale);
-        gui.setColor(1.0F, 1.0F, 1.0F, 1.0F);
+        //gui.setColor(1.0F, 1.0F, 1.0F, 1.0F);
 
         gui.pose().popPose();
 

--- a/src/main/java/com/robertx22/mine_and_slash/gui/screens/skill_tree/buttons/PerkButton.java
+++ b/src/main/java/com/robertx22/mine_and_slash/gui/screens/skill_tree/buttons/PerkButton.java
@@ -1,11 +1,13 @@
 package com.robertx22.mine_and_slash.gui.screens.skill_tree.buttons;
 
+import com.google.common.collect.HashMultimap;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.robertx22.mine_and_slash.capability.player.PlayerData;
 import com.robertx22.mine_and_slash.database.data.perks.Perk;
 import com.robertx22.mine_and_slash.database.data.perks.PerkStatus;
 import com.robertx22.mine_and_slash.database.data.stats.types.UnknownStat;
 import com.robertx22.mine_and_slash.database.data.talent_tree.TalentTree;
+import com.robertx22.mine_and_slash.gui.screens.skill_tree.BufferInfo;
 import com.robertx22.mine_and_slash.gui.screens.skill_tree.SkillTreeScreen;
 import com.robertx22.mine_and_slash.mmorpg.MMORPG;
 import com.robertx22.mine_and_slash.mmorpg.SlashRef;
@@ -24,6 +26,7 @@ import net.minecraft.client.gui.components.Tooltip;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
+import org.joml.Matrix4f;
 
 import java.util.List;
 
@@ -139,13 +142,13 @@ public class PerkButton extends ImageButton {
         }
     }
 
-    int xPos(float offset, float multi) {
-        return (int) ((this.getX() * multi) + offset);
+    float xPos(float offset, float multi) {
+        return ((this.getX() * multi) + offset);
 
     }
 
-    int yPos(float offset, float multi) {
-        return (int) ((getY() * multi) + offset);
+    float yPos(float offset, float multi) {
+        return ((getY() * multi) + offset);
     }
 
     @Override
@@ -169,7 +172,7 @@ public class PerkButton extends ImageButton {
         float add = MathHelper.clamp(scale - 1, 0, 2);
         float off = width / -2F * add;
         gui.pose().translate(off, off, 0);
-        gui.pose().scale(scale, scale, scale);
+        gui.pose().scale(scale, scale, 1.0f);
 
 
         PerkStatus status = playerData.talents.getStatus(Minecraft.getInstance().player, school, point);
@@ -189,7 +192,6 @@ public class PerkButton extends ImageButton {
 
 
         float opacity = search.isEmpty() || containsSearchStat || containsName ? 1F : 0.2f;
-
 
         if (!search.isEmpty()) {
             if (search.equals("all")) {
@@ -216,10 +218,16 @@ public class PerkButton extends ImageButton {
 
         gui.setColor(1.0F, 1.0F, 1.0F, opacity);
 
+        HashMultimap<ResourceLocation, BufferInfo> container = screen.vertexContainer.map;
+        var matrix4f = new Matrix4f(gui.pose().last().pose());
 
-        // if i can merge these 2 icons into 1, i can remove 20% of the lag todo
-        gui.blit(perk.getType().getColorTexture(status), xPos(offcolor, posMulti), yPos(offcolor, posMulti), 20, 20, 0, 0, 20, 20, 20, 20);
-        gui.blit(perk.getType().getBorderTexture(status), (int) xPos(0, posMulti), (int) yPos(0, posMulti), 0, 0, this.width, this.height, this.width, this.height);
+        //BlitOffset indicate the distance to the camera.
+        //bigger = closer
+        container.put(perk.getType().getColorTexture(status), BufferInfo.of(xPos(offcolor, posMulti), yPos(offcolor, posMulti),20, 20, -3, 0.0f, 0, 20, 20, 20, 20, matrix4f).withRenderInfo(new BufferInfo.RenderInfo(opacity)));
+
+        container.put(perk.getType().getBorderTexture(status), BufferInfo.of(xPos(0, posMulti), yPos(0, posMulti), -2, 0, 0, this.width, this.height, this.width, this.height, matrix4f).withRenderInfo(new BufferInfo.RenderInfo(opacity)));
+
+
 
         if (search.isEmpty()) {
             opacity += 0.2F;
@@ -228,7 +236,8 @@ public class PerkButton extends ImageButton {
 
         gui.setColor(1.0F, 1.0F, 1.0F, MathHelper.clamp(opacity, 0, 1));
 
-        gui.blit(perk.getIcon(), (int) xPos(offset, posMulti), (int) yPos(offset, posMulti), 0, 0, type.iconSize, type.iconSize, type.iconSize, type.iconSize);
+        container.put(perk.getIcon(), BufferInfo.of(xPos(offset, posMulti), yPos(offset, posMulti), -1, 0, 0, type.iconSize, type.iconSize, type.iconSize, type.iconSize, matrix4f).withRenderInfo(new BufferInfo.RenderInfo(opacity)));
+
 
 
         //   gui.pose().scale(1F / scale, 1F / scale, 1F / scale);

--- a/src/main/java/com/robertx22/mine_and_slash/gui/screens/skill_tree/buttons/PerkButton.java
+++ b/src/main/java/com/robertx22/mine_and_slash/gui/screens/skill_tree/buttons/PerkButton.java
@@ -222,13 +222,12 @@ public class PerkButton extends ImageButton {
         //gui.setColor(1.0F, 1.0F, 1.0F, opacity);
 
         HashMultimap<ResourceLocation, BufferInfo> container = screen.vertexContainer.map;
-        var matrix4f = new Matrix4f(gui.pose().last().pose());
 
         //BlitOffset indicate the distance to the camera.
         //bigger = closer
-        container.put(perk.getType().getColorTexture(status), BufferInfo.of(xPos(offcolor, posMulti), yPos(offcolor, posMulti),20, 20, -3, 0.0f, 0, 20, 20, 20, 20, matrix4f).withRenderInfo(new BufferInfo.RenderInfo(opacity)));
+        container.put(perk.getType().getColorTexture(status), BufferInfo.of(xPos(offcolor, posMulti), yPos(offcolor, posMulti),20, 20, -3, 0.0f, 0, 20, 20, 20, 20, gui.pose().last().pose()).withRenderInfo(new BufferInfo.RenderInfo(opacity)));
 
-        container.put(perk.getType().getBorderTexture(status), BufferInfo.of(xPos(0, posMulti), yPos(0, posMulti), -2, 0, 0, this.width, this.height, this.width, this.height, matrix4f).withRenderInfo(new BufferInfo.RenderInfo(opacity)));
+        container.put(perk.getType().getBorderTexture(status), BufferInfo.of(xPos(0, posMulti), yPos(0, posMulti), -2, 0, 0, this.width, this.height, this.width, this.height, gui.pose().last().pose()).withRenderInfo(new BufferInfo.RenderInfo(opacity)));
 
 
 
@@ -239,7 +238,7 @@ public class PerkButton extends ImageButton {
 
         //gui.setColor(1.0F, 1.0F, 1.0F, MathHelper.clamp(opacity, 0, 1));
 
-        container.put(perk.getIcon(), BufferInfo.of(xPos(offset, posMulti), yPos(offset, posMulti), -1, 0, 0, type.iconSize, type.iconSize, type.iconSize, type.iconSize, matrix4f).withRenderInfo(new BufferInfo.RenderInfo(opacity)));
+        container.put(perk.getIcon(), BufferInfo.of(xPos(offset, posMulti), yPos(offset, posMulti), -1, 0, 0, type.iconSize, type.iconSize, type.iconSize, type.iconSize, gui.pose().last().pose()).withRenderInfo(new BufferInfo.RenderInfo(opacity)));
 
 
 

--- a/src/main/java/com/robertx22/mine_and_slash/gui/screens/skill_tree/buttons/PerkConnectionRender.java
+++ b/src/main/java/com/robertx22/mine_and_slash/gui/screens/skill_tree/buttons/PerkConnectionRender.java
@@ -1,34 +1,20 @@
 package com.robertx22.mine_and_slash.gui.screens.skill_tree.buttons;
 
+import com.google.common.base.Objects;
 import com.robertx22.mine_and_slash.database.data.perks.Perk;
 import com.robertx22.mine_and_slash.saveclasses.PointData;
 
-public class PerkConnectionRender {
-
-    public PointData perk1, perk2;
-    public Perk.Connection connection;
-
-    public PerkConnectionRender(PointData perk1, PointData perk2,
-                                Perk.Connection connection) {
-        this.perk1 = perk1;
-        this.perk2 = perk2;
-        this.connection = connection;
-    }
+public record PerkConnectionRender(PerkPointPair pair, Perk.Connection connection) {
 
     @Override
-    public boolean equals(Object o) {
-        if (o instanceof PerkConnectionRender p) {
-            if ((perk1.equals(p.perk1) || perk1.equals(p.perk2)) && (perk2.equals(p.perk1) || perk2.equals(p.perk2))) {
-                return true;
-            }
-        }
-        return false;
+    public boolean equals(Object object) {
+        if (this == object) return true;
+        if (!(object instanceof PerkConnectionRender that)) return false;
+        return Objects.equal(pair, that.pair) && connection == that.connection;
     }
 
     @Override
     public int hashCode() {
-        int result = perk1.hashCode();
-        result = 31 * result + perk2.hashCode();
-        return result;
+        return Objects.hashCode(pair);
     }
 }

--- a/src/main/java/com/robertx22/mine_and_slash/gui/screens/skill_tree/buttons/PerkPointPair.java
+++ b/src/main/java/com/robertx22/mine_and_slash/gui/screens/skill_tree/buttons/PerkPointPair.java
@@ -1,0 +1,28 @@
+package com.robertx22.mine_and_slash.gui.screens.skill_tree.buttons;
+
+import com.robertx22.mine_and_slash.saveclasses.PointData;
+
+public record PerkPointPair(PointData data1, PointData data2) {
+
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof PerkPointPair p) {
+            return (data1.equals(p.data1) || data1.equals(p.data2)) && (data2.equals(p.data1) || data2.equals(p.data2));
+        }
+        return false;
+    }
+    //the order of data1 and data2 will not change the hashcode of pair.
+    @Override
+    public int hashCode() {
+        int hashA = data1.hashCode();
+        int hashB = data2.hashCode();
+
+        long result = 17;
+        result = 31 * result + (hashA ^ hashB);
+        result = 31 * result + (hashA & hashB);
+        result = 31 * result + (hashA | hashB);
+
+        return (int) result;
+    }
+
+}

--- a/src/main/java/com/robertx22/mine_and_slash/gui/wiki/reworked/NewWikiScreen.java
+++ b/src/main/java/com/robertx22/mine_and_slash/gui/wiki/reworked/NewWikiScreen.java
@@ -133,10 +133,12 @@ public class NewWikiScreen extends Screen implements INamedScreen {
     }
 
     public boolean charTyped(char pCodePoint, int pModifiers) {
+        this.searchBox.setFocused(true);
         return this.searchBox.charTyped(pCodePoint, pModifiers);
     }
 
     public void render(GuiGraphics pGuiGraphics, int pMouseX, int pMouseY, float pPartialTick) {
+
         this.list.render(pGuiGraphics, pMouseX, pMouseY, pPartialTick);
         this.searchBox.render(pGuiGraphics, pMouseX, pMouseY, pPartialTick);
         pGuiGraphics.drawCenteredString(this.font, this.title, this.width / 2, 8, 16777215);

--- a/src/main/java/com/robertx22/mine_and_slash/saveclasses/PointData.java
+++ b/src/main/java/com/robertx22/mine_and_slash/saveclasses/PointData.java
@@ -38,9 +38,17 @@ public class PointData {
 
     @Override
     public int hashCode() {
-        long bits = java.lang.Double.doubleToLongBits(x);
-        bits ^= java.lang.Double.doubleToLongBits(y) * 31;
-        return (((int) bits) ^ ((int) (bits >> 32)));
+        long bitsX = Double.doubleToLongBits(x);
+        long bitsY = Double.doubleToLongBits(y);
+
+        long h = bitsX ^ (bitsY * 31);
+        h = (h >>> 32) ^ h;
+        h = h * 0x27d4eb2d;
+        h = h ^ (h >>> 33);
+        h = h * 0x165667b1;
+        h = h ^ (h >>> 31);
+
+        return Long.hashCode(h);
     }
 
     @Override


### PR DESCRIPTION
1. reduce the total number of draw calls from 1980 to 73
2. change some perk button check place
3. optimize the algorithm for recalculating the connection renderer.
4. use float to control the texture position, now the button texture will not jitter when you zoom or drag the screen.
5. misc change about the chartype and button status reset(first commit)

On my PC, screen render time decreased from 30000+ ms to 3000+ ms.