### PR TITLE
Fix instant cast spells being canceled when hitting an enemy on the same tick

### DIFF
--- a/src/main/java/com/robertx22/mine_and_slash/event_hooks/player/StopCastingIfInteract.java
+++ b/src/main/java/com/robertx22/mine_and_slash/event_hooks/player/StopCastingIfInteract.java
@@ -14,7 +14,7 @@ public class StopCastingIfInteract {
         }
         var data = Load.player(player);
 
-        if (data.spellCastingData.isCasting()) {
+        if (data.spellCastingData.isCasting() && data.spellCastingData.castTickLeft > 0) {
             data.spellCastingData.cancelCast(player);
             data.playerDataSync.setDirty();
         }


### PR DESCRIPTION
This prevents spells from being canceled by interaction on the tick they would cast, mainly fixing spell casts with unlucky timing getting eaten when holding left click on an enemy in CTE2.