### PR TITLE
Infinite duration exile effects

### DIFF
--- a/src/main/java/com/robertx22/mine_and_slash/aoe_data/database/spells/PartBuilder.java
+++ b/src/main/java/com/robertx22/mine_and_slash/aoe_data/database/spells/PartBuilder.java
@@ -279,20 +279,6 @@ public class PartBuilder {
         return c;
     }
 
-    public static ComponentPart giveSelfExileEffect(String effect) {
-        ComponentPart c = new ComponentPart();
-        c.acts.add(SpellAction.EXILE_EFFECT.create(effect, GiveOrTake.GIVE_STACKS));
-        c.targets.add(BaseTargetSelector.CASTER.create());
-        return c;
-    }
-
-    public static ComponentPart giveSelfExileEffect(EffectCtx ctx) {
-        ComponentPart c = new ComponentPart();
-        c.acts.add(SpellAction.EXILE_EFFECT.create(ctx.resourcePath, GiveOrTake.GIVE_STACKS));
-        c.targets.add(BaseTargetSelector.CASTER.create());
-        return c;
-    }
-
     public static ComponentPart giveSelfEffect(MobEffect effect, Double dura) {
         ComponentPart c = new ComponentPart();
         c.acts.add(SpellAction.POTION.createGive(effect, dura));

--- a/src/main/java/com/robertx22/mine_and_slash/aoe_data/database/spells/PartBuilder.java
+++ b/src/main/java/com/robertx22/mine_and_slash/aoe_data/database/spells/PartBuilder.java
@@ -279,6 +279,20 @@ public class PartBuilder {
         return c;
     }
 
+    public static ComponentPart giveSelfExileEffect(String effect) {
+        ComponentPart c = new ComponentPart();
+        c.acts.add(SpellAction.EXILE_EFFECT.create(effect, GiveOrTake.GIVE_STACKS));
+        c.targets.add(BaseTargetSelector.CASTER.create());
+        return c;
+    }
+
+    public static ComponentPart giveSelfExileEffect(EffectCtx ctx) {
+        ComponentPart c = new ComponentPart();
+        c.acts.add(SpellAction.EXILE_EFFECT.create(ctx.resourcePath, GiveOrTake.GIVE_STACKS));
+        c.targets.add(BaseTargetSelector.CASTER.create());
+        return c;
+    }
+
     public static ComponentPart giveSelfEffect(MobEffect effect, Double dura) {
         ComponentPart c = new ComponentPart();
         c.acts.add(SpellAction.POTION.createGive(effect, dura));
@@ -292,7 +306,6 @@ public class PartBuilder {
         c.targets.add(BaseTargetSelector.AOE.alliesInRadius(radius));
         return c;
     }
-
 
     public static ComponentPart giveExileEffectToAlliesInRadius(Double radius, String effect, Double dura) {
         ComponentPart c = new ComponentPart();

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/exile_effects/ExileEffectInstanceData.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/exile_effects/ExileEffectInstanceData.java
@@ -20,6 +20,15 @@ public class ExileEffectInstanceData {
     public float str_multi = 1;
     public int ticks_left = 0;
 
+    public boolean stillOwnsSpell(LivingEntity en) {
+        if (caster_uuid.equals(en.getStringUUID())) {
+            Spell spell = getSpell();
+            if (spell != null && spell.getLevelOf(en) == 0) {
+                return false;
+            }
+        }
+        return true;
+    }
 
     public boolean shouldRemove() {
         return ticks_left < 1 || stacks < 1;

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/exile_effects/ExileEffectInstanceData.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/exile_effects/ExileEffectInstanceData.java
@@ -14,28 +14,34 @@ public class ExileEffectInstanceData {
 
     public CalculatedSpellData calcSpell = new CalculatedSpellData(null);
 
+    public boolean self_cast = false;
+    public boolean is_infinite = false;
     public String caster_uuid = "";
     public String spell_id = "";
     public int stacks = 0;
     public float str_multi = 1;
     public int ticks_left = 0;
 
-    public boolean stillOwnsSpell(LivingEntity en) {
-        if (caster_uuid.equals(en.getStringUUID())) {
+    public boolean isSpellNoLongerAllocated(LivingEntity en) {
+        if (self_cast) {
             Spell spell = getSpell();
-            if (spell != null && spell.getLevelOf(en) == 0) {
-                return false;
+            if (spell != null && spell.getLevelOf(en) < 1) {
+                return true;
             }
         }
-        return true;
+        return false;
     }
 
     public boolean shouldRemove() {
-        return ticks_left < 1 || stacks < 1;
+        return stacks < 1 || (!is_infinite && ticks_left < 1);
     }
 
-
     public String getDurationString() {
+        if (is_infinite) {
+            // Infinity symbol
+            return "\u221E";
+        }
+
         int ticks = ticks_left;
         int sec = ticks / 20;
         String text = (int) sec + "s";

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/actions/ExileEffectAction.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/actions/ExileEffectAction.java
@@ -36,8 +36,10 @@ public class ExileEffectAction extends SpellAction {
         }
     }
 
+    public static Double INFINITE_DURATION = -1D;
+
     public ExileEffectAction() {
-        super(Arrays.asList(EXILE_POTION_ID, COUNT, POTION_ACTION)); // optional POTION_DURATION
+        super(Arrays.asList(EXILE_POTION_ID, COUNT, POTION_ACTION, POTION_DURATION));
     }
 
     @Override
@@ -48,9 +50,9 @@ public class ExileEffectAction extends SpellAction {
             GiveOrTake action = data.getPotionAction();
             int count = data.get(COUNT)
                     .intValue();
-            int duration = data.getOrDefault(POTION_DURATION, 0.0)
+            int duration = data.get(POTION_DURATION)
                     .intValue();
-            boolean infinite = !data.has(POTION_DURATION);
+            boolean infinite = data.get(POTION_DURATION).equals(INFINITE_DURATION);
 
             float chance = data.getOrDefault(CHANCE, 100D).floatValue();
 
@@ -91,15 +93,6 @@ public class ExileEffectAction extends SpellAction {
         dmg.type = GUID();
         dmg.put(COUNT, 1D);
         dmg.put(POTION_DURATION, duration);
-        dmg.put(POTION_ACTION, action.name());
-        dmg.put(EXILE_POTION_ID, id);
-        return dmg;
-    }
-
-    public MapHolder create(String id, GiveOrTake action) {
-        MapHolder dmg = new MapHolder();
-        dmg.type = GUID();
-        dmg.put(COUNT, 1D);
         dmg.put(POTION_ACTION, action.name());
         dmg.put(EXILE_POTION_ID, id);
         return dmg;

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/actions/ExileEffectAction.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/actions/ExileEffectAction.java
@@ -37,7 +37,7 @@ public class ExileEffectAction extends SpellAction {
     }
 
     public ExileEffectAction() {
-        super(Arrays.asList(EXILE_POTION_ID, COUNT, POTION_ACTION, POTION_DURATION));
+        super(Arrays.asList(EXILE_POTION_ID, COUNT, POTION_ACTION)); // optional POTION_DURATION
     }
 
     @Override
@@ -48,8 +48,9 @@ public class ExileEffectAction extends SpellAction {
             GiveOrTake action = data.getPotionAction();
             int count = data.get(COUNT)
                     .intValue();
-            int duration = data.get(POTION_DURATION)
+            int duration = data.getOrDefault(POTION_DURATION, 0.0)
                     .intValue();
+            boolean infinite = !data.has(POTION_DURATION);
 
             float chance = data.getOrDefault(CHANCE, 100D).floatValue();
 
@@ -57,7 +58,7 @@ public class ExileEffectAction extends SpellAction {
 
                 if (RandomUtils.roll(chance)) {
                     ExilePotionEvent potionEvent = EventBuilder.ofEffect(ctx.calculatedSpellData, ctx.caster, t, Load.Unit(ctx.caster)
-                                    .getLevel(), potion, action.getOther(), duration)
+                                    .getLevel(), potion, action.getOther(), duration, infinite)
                             .setSpell(ctx.calculatedSpellData.getSpell())
                             .set(x -> x.data.getNumber(EventData.STACKS).number = count)
                             .build();
@@ -90,6 +91,15 @@ public class ExileEffectAction extends SpellAction {
         dmg.type = GUID();
         dmg.put(COUNT, 1D);
         dmg.put(POTION_DURATION, duration);
+        dmg.put(POTION_ACTION, action.name());
+        dmg.put(EXILE_POTION_ID, id);
+        return dmg;
+    }
+
+    public MapHolder create(String id, GiveOrTake action) {
+        MapHolder dmg = new MapHolder();
+        dmg.type = GUID();
+        dmg.put(COUNT, 1D);
         dmg.put(POTION_ACTION, action.name());
         dmg.put(EXILE_POTION_ID, id);
         return dmg;

--- a/src/main/java/com/robertx22/mine_and_slash/uncommon/effectdatas/EventBuilder.java
+++ b/src/main/java/com/robertx22/mine_and_slash/uncommon/effectdatas/EventBuilder.java
@@ -17,8 +17,8 @@ public class EventBuilder<T extends EffectEvent> {
 
     protected T event;
 
-    public static EventBuilder<ExilePotionEvent> ofEffect(CalculatedSpellData calc, LivingEntity caster, LivingEntity target, int lvl, ExileEffect effect, GiveOrTake2 giveOrTake, int ticks) {
-        ExilePotionEvent event = new ExilePotionEvent(calc, lvl, effect, giveOrTake, caster, target, ticks);
+    public static EventBuilder<ExilePotionEvent> ofEffect(CalculatedSpellData calc, LivingEntity caster, LivingEntity target, int lvl, ExileEffect effect, GiveOrTake2 giveOrTake, int ticks, boolean infinite) {
+        ExilePotionEvent event = new ExilePotionEvent(calc, lvl, effect, giveOrTake, caster, target, ticks, infinite);
         EventBuilder<ExilePotionEvent> b = new EventBuilder();
         b.event = event;
         return b;

--- a/src/main/java/com/robertx22/mine_and_slash/uncommon/effectdatas/ExilePotionEvent.java
+++ b/src/main/java/com/robertx22/mine_and_slash/uncommon/effectdatas/ExilePotionEvent.java
@@ -28,7 +28,7 @@ public class ExilePotionEvent extends EffectEvent {
 
     CalculatedSpellData calc;
 
-    public ExilePotionEvent(CalculatedSpellData calc, int lvl, ExileEffect effect, GiveOrTake2 giveOrTake, LivingEntity caster, LivingEntity target, int tickDuration) {
+    public ExilePotionEvent(CalculatedSpellData calc, int lvl, ExileEffect effect, GiveOrTake2 giveOrTake, LivingEntity caster, LivingEntity target, int tickDuration, boolean infinite) {
         super(1, caster, target);
         this.lvl = lvl;
         this.calc = calc;
@@ -37,7 +37,7 @@ public class ExilePotionEvent extends EffectEvent {
         this.data.setString(EventData.GIVE_OR_TAKE, giveOrTake.name());
         this.data.setString(EventData.EXILE_EFFECT, effect.GUID());
         this.data.setupNumber(EventData.EFFECT_DURATION_TICKS, tickDuration);
-
+        this.data.setBoolean(EventData.EFFECT_IS_INFINITE, infinite);
     }
 
     @Override
@@ -75,12 +75,13 @@ public class ExilePotionEvent extends EffectEvent {
 
         }
 
-
+        extraData.self_cast = source == target;
         extraData.caster_uuid = source.getStringUUID();
         extraData.spell_id = this.spellid;
         extraData.str_multi = data.getNumber();
         extraData.calcSpell = this.calc;
         extraData.ticks_left = (int) data.getNumber(EventData.EFFECT_DURATION_TICKS).number;
+        extraData.is_infinite = data.getBoolean(EventData.EFFECT_IS_INFINITE);
 
         if (extraData.stacks < 1) {
             Load.Unit(target).getStatusEffectsData().delete(effect);

--- a/src/main/java/com/robertx22/mine_and_slash/uncommon/effectdatas/rework/EventData.java
+++ b/src/main/java/com/robertx22/mine_and_slash/uncommon/effectdatas/rework/EventData.java
@@ -53,6 +53,7 @@ public class EventData {
 
     public static String CAST_TICKS = "cast_ticks";
     public static String EFFECT_DURATION_TICKS = "effect_duration_ticks";
+    public static String EFFECT_IS_INFINITE = "effect_is_infinite";
     public static String COOLDOWN_TICKS = "cd_ticks";
     public static String CHARGE_COOLDOWN_TICKS = "charge_cd_ticks";
     public static String MANA_COST = "mana_cost";

--- a/src/main/java/com/robertx22/mine_and_slash/uncommon/effectdatas/rework/action/GiveExileStatusEffect.java
+++ b/src/main/java/com/robertx22/mine_and_slash/uncommon/effectdatas/rework/action/GiveExileStatusEffect.java
@@ -34,7 +34,7 @@ public class GiveExileStatusEffect extends StatEffect {
 
         ExilePotionEvent potionEvent = EventBuilder.ofEffect(new CalculatedSpellData(null), event.getSide(statSource), event.getSide(give_to), Load.Unit(event.getSide(statSource))
                         .getLevel(), ExileDB.ExileEffects()
-                        .get(effect), GiveOrTake2.give, seconds * 20)
+                        .get(effect), GiveOrTake2.give, seconds * 20, false)
                 .set(x -> {
                     if (event.isSpell()) {
                         x.data.setString(EventData.SPELL, event.getSpell().GUID());

--- a/src/main/java/com/robertx22/mine_and_slash/uncommon/effectdatas/rework/action/GiveExileStatusInRadius.java
+++ b/src/main/java/com/robertx22/mine_and_slash/uncommon/effectdatas/rework/action/GiveExileStatusInRadius.java
@@ -49,7 +49,7 @@ public class GiveExileStatusInRadius extends StatEffect {
                 .forEach(x -> {
 
                     ExilePotionEvent potionEvent = EventBuilder.ofEffect(new CalculatedSpellData(null), en, x, Load.Unit(en)
-                                    .getLevel(), eff, GiveOrTake2.give, seconds * 20)
+                                    .getLevel(), eff, GiveOrTake2.give, seconds * 20, false)
                             .build();
                     potionEvent.Activate();
 

--- a/src/main/java/com/robertx22/mine_and_slash/uncommon/effectdatas/rework/action/RemoveExileEffectAction.java
+++ b/src/main/java/com/robertx22/mine_and_slash/uncommon/effectdatas/rework/action/RemoveExileEffectAction.java
@@ -32,7 +32,7 @@ public class RemoveExileEffectAction extends StatEffect {
     public void activate(EffectEvent event, EffectSides statSource, StatData data, Stat stat) {
         ExilePotionEvent potionEvent = EventBuilder.ofEffect(new CalculatedSpellData(null), event.getSide(statSource), event.getSide(remove_from), Load.Unit(event.getSide(statSource))
                         .getLevel(), ExileDB.ExileEffects()
-                        .get(effect), GiveOrTake2.take, 1)
+                        .get(effect), GiveOrTake2.take, 1, false)
                 .set(x -> x.data.getNumber(EventData.STACKS).number = stacks)
                 .build();
         potionEvent.Activate();

--- a/src/main/java/com/robertx22/mine_and_slash/vanilla_mc/potion_effects/EntityStatusEffectsData.java
+++ b/src/main/java/com/robertx22/mine_and_slash/vanilla_mc/potion_effects/EntityStatusEffectsData.java
@@ -46,13 +46,25 @@ public class EntityStatusEffectsData {
         // todo this is probably bit laggy per tick no?
         List<ExileEffect> removed = new ArrayList<>();
 
-        exileMap.entrySet().removeIf(x -> {
-            boolean bo = x.getValue().shouldRemove();
-            if (bo) {
-                removed.add(ExileDB.ExileEffects().get(x.getKey()));
-            }
-            return bo;
-        });
+        if (en.tickCount % 80 == 0) {
+            // Prevent keeping e.g. auras and stances after respeccing
+            // Has to string compare caster UUID per effect to see if it was us, so it's done infrequently
+            exileMap.entrySet().removeIf(x -> {
+                if (x.getValue().shouldRemove() || !x.getValue().stillOwnsSpell(en)) {
+                    removed.add(ExileDB.ExileEffects().get(x.getKey()));
+                    return true;
+                }
+                return false;
+            });
+        } else {
+            exileMap.entrySet().removeIf(x -> {
+                if (x.getValue().shouldRemove()) {
+                    removed.add(ExileDB.ExileEffects().get(x.getKey()));
+                    return true;
+                }
+                return false;
+            });
+        }
 
         for (ExileEffect eff : removed) {
             eff.onRemove(en);

--- a/src/main/java/com/robertx22/mine_and_slash/vanilla_mc/potion_effects/EntityStatusEffectsData.java
+++ b/src/main/java/com/robertx22/mine_and_slash/vanilla_mc/potion_effects/EntityStatusEffectsData.java
@@ -48,9 +48,9 @@ public class EntityStatusEffectsData {
 
         if (en.tickCount % 80 == 0) {
             // Prevent keeping e.g. auras and stances after respeccing
-            // Has to string compare caster UUID per effect to see if it was us, so it's done infrequently
+            // Has to string compare spell UUIDs to look up the new spell level, so it's done infrequently
             exileMap.entrySet().removeIf(x -> {
-                if (x.getValue().shouldRemove() || !x.getValue().stillOwnsSpell(en)) {
+                if (x.getValue().shouldRemove() || x.getValue().isSpellNoLongerAllocated(en)) {
                     removed.add(ExileDB.ExileEffects().get(x.getKey()));
                     return true;
                 }


### PR DESCRIPTION
This adds support for applying infinite duration self buffs (auras, stances) by omitting `potion_dur`. All self-applied effects will now occasionally check to see if you still have the spell that granted them.