### PR TITLE
Correct aggro radius for summons

### DIFF
--- a/src/main/java/com/robertx22/mine_and_slash/aoe_data/database/spells/SpellBuilder.java
+++ b/src/main/java/com/robertx22/mine_and_slash/aoe_data/database/spells/SpellBuilder.java
@@ -74,17 +74,27 @@ public class SpellBuilder {
         return this;
     }
 
-    public SpellBuilder summons(EntityType type, int duration, int amount, SummonType st, boolean countsTowardsMax) {
-        onCast(PartBuilder.justAction(SummonPetAction.SUMMON_PET.create(type, duration, amount, st, countsTowardsMax)))
+    public SpellBuilder summons(EntityType type, int duration, int amount, SummonType st, boolean countsTowardsMax, int aggroRadius) {
+        onCast(PartBuilder.justAction(SummonPetAction.SUMMON_PET.create(type, duration, amount, st, countsTowardsMax, aggroRadius)))
                 .onCast(PartBuilder.aoeParticles(ParticleTypes.WITCH, 200D, 3.5D))
                 .onCast(PartBuilder.aoeParticles(ParticleTypes.SOUL, 200D, 3.5D))
                 .onCast(PartBuilder.playSound(SoundEvents.EVOKER_PREPARE_SUMMON, 0.5D, 1D));
         return this;
     }
 
+    public SpellBuilder summons(EntityType type, int duration, int amount, SummonType st, boolean countsTowardsMax) {
+
+        return summons(type, duration, amount, st, countsTowardsMax, 15);
+    }
+
+    public SpellBuilder summons(EntityType type, int duration, int amount, SummonType st, int aggroRadius) {
+
+        return summons(type, duration, amount, st, true, aggroRadius);
+    }
+
     public SpellBuilder summons(EntityType type, int duration, int amount, SummonType st) {
 
-        return summons(type, duration, amount, st, true);
+        return summons(type, duration, amount, st, true, 15);
     }
 
     public SpellBuilder teleportForward() {

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/SpellConfiguration.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/SpellConfiguration.java
@@ -20,7 +20,7 @@ public class SpellConfiguration {
     public int times_to_cast = 1;
     public int charges = 0;
     public int charge_regen = 0;
-    public int aggro_radius = 10;
+    public int aggro_radius = 1;
     public int imbues = 0;
     public SummonType summonType = SummonType.NONE;
     public String charge_name = "";

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/actions/SummonPetAction.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/actions/SummonPetAction.java
@@ -53,7 +53,7 @@ public class SummonPetAction extends SpellAction {
             int duration = data.get(MapField.LIFESPAN_TICKS).intValue();
             duration *= ctx.calculatedSpellData.data.getNumber(EventData.DURATION_MULTI, 1).number;
 
-            int aggroRadius = data.get(MapField.LIFESPAN_TICKS).intValue();
+            int aggroRadius = data.get(MapField.AGGRO_RADIUS).intValue();
             aggroRadius *= ctx.calculatedSpellData.data.getNumber(EventData.AGGRO_RADIUS, 1).number;
 
 
@@ -105,12 +105,13 @@ public class SummonPetAction extends SpellAction {
         }
     }
 
-    public MapHolder create(EntityType type, int lifespan, int amount, SummonType st, boolean counts) {
+    public MapHolder create(EntityType type, int lifespan, int amount, SummonType st, boolean counts, int aggroRadius) {
         MapHolder c = new MapHolder();
         c.put(MapField.SUMMON_TYPE, st.name());
         c.put(MapField.SUMMONED_PET_ID, EntityType.getKey(type).toString());
         c.put(MapField.ENTITY_NAME, Spell.DEFAULT_EN_NAME);
         c.put(MapField.LIFESPAN_TICKS, (double) lifespan);
+        c.put(MapField.AGGRO_RADIUS, (double) aggroRadius);
         c.put(MapField.COUNT, (double) amount);
         c.put(MapField.COUNTS_TOWARDS_MAX_SUMMONS, counts);
         c.type = GUID();

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/map_fields/MapField.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/map_fields/MapField.java
@@ -22,6 +22,7 @@ public class MapField<T> implements IGUID {
     public static MapField<Double> PARTICLE_COUNT = make("particle_count");
     public static MapField<Double> Y_RANDOM = make("y_rand");
     public static MapField<Double> LIFESPAN_TICKS = make("life_ticks");
+    public static MapField<Double> AGGRO_RADIUS = make("aggro_radius");
     public static MapField<Double> PROJECTILE_SPREAD_RANDOMNESS = make("projectile_spread_randomness");
     public static MapField<Double> DISTANCE = make("distance");
     public static MapField<Double> WIDTH = make("width");


### PR DESCRIPTION
Previous it can get to 24000 and that's probably why there were some complains about summons not clearing closest targets but going to some distant enemies