### PR TITLE
Improve spell input handling

### DIFF
--- a/src/main/java/com/robertx22/mine_and_slash/database/data/game_balance_config/GameBalanceConfig.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/game_balance_config/GameBalanceConfig.java
@@ -72,6 +72,8 @@ public class GameBalanceConfig implements JsonExileRegistry<GameBalanceConfig>, 
 
     public double MIN_SPELL_COOLDOWN_MULTI = 0.2;
 
+    public int GLOBAL_COOLDOWN_TICKS = 3;
+
     public double CRAFTED_GEAR_POTENTIAL_MULTI = 0.5;
 
     public int MAX_BONUS_SPELL_LEVELS = 5;

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/SpellConfiguration.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/SpellConfiguration.java
@@ -82,15 +82,7 @@ public class SpellConfiguration {
         this.charge_regen = ticksToRegen;
         this.charges = charges;
         this.charge_name = name;
-
-
-        if (ticksToRegen > (20 * 30)) {
-            this.cooldown_ticks = 0; // we force the cooldown to be the same for all spells with charges so it feels consistent and good
-        } else {
-            this.cooldown_ticks = 0; // we force the cooldown to be the same for all spells with charges so it feels consistent and good
-        }
-
-
+        this.cooldown_ticks = 3; // we force the cooldown to be the same for all spells with charges so it feels consistent and good
         return this;
     }
 

--- a/src/main/java/com/robertx22/mine_and_slash/event_hooks/player/OnKeyPress.java
+++ b/src/main/java/com/robertx22/mine_and_slash/event_hooks/player/OnKeyPress.java
@@ -1,5 +1,7 @@
 package com.robertx22.mine_and_slash.event_hooks.player;
 
+import java.util.Stack;
+
 import com.robertx22.library_of_exile.main.Packets;
 import com.robertx22.mine_and_slash.config.forge.ClientConfigs;
 import com.robertx22.mine_and_slash.gui.screens.character_screen.MainHubScreen;
@@ -16,13 +18,15 @@ public class OnKeyPress {
 
     public static int cooldown = 0;
 
+    // Store what order spell keys are pressed in to prioritize most recently pressed
+    private static Stack<SpellKeybind> spellKeysPressed = new Stack<>();
+
+    // Number of last spell sent to the server
+    private static int lastSpellNumber = -1;
+    // Timer to resend packet so the server knows we want to keep casting
+    private static int spellPacketResendTimer = 0;
 
     public static void onEndTick(Minecraft mc) {
-
-        if (cooldown > 0) {
-            cooldown--;
-            return;
-        }
 
         if (mc.player == null) {
             return;
@@ -32,6 +36,12 @@ public class OnKeyPress {
             return;
         }
 
+        updateSpellInputs();
+
+        if (cooldown > 0) {
+            cooldown--;
+            return;
+        }
 
         if (KeybindsRegister.UNSUMMON.isDown()) {
             Packets.sendToServer(new UnsummonPacket());
@@ -44,46 +54,63 @@ public class OnKeyPress {
             cooldown = 5;
         } else if (KeybindsRegister.QUICK_DRINK_POTION.consumeClick()) {
             Packets.sendToServer(new QuickUsePotionPacket());
-        } else {
+        }
+    }
 
-            int number = -1;
-
-            var keys = SpellKeybind.ALL;
-
-            if (ClientConfigs.getConfig().HOTBAR_SWAPPING.get()) {
-                keys = SpellKeybind.FIRST_HOTBAR_KEYS;
-            }
-
-            for (SpellKeybind key : keys) {
-                if (key.key.isDown()) {
-                    number = key.getIndex();
-                }
-            }
-            // we always use the key modifier when both are pressed but use same keybind
-            for (SpellKeybind key : keys) {
-                if (key.key.getKeyModifier() != KeyModifier.NONE && key.key.isDown()) {
-                    number = key.getIndex();
-                }
-            }
-
-            // try see if consuming clicks fixes the random key bugs
-            for (SpellKeybind key : SpellKeybind.ALL) {
-                key.key.consumeClick();
-            }
-
-            if (ClientConfigs.getConfig().HOTBAR_SWAPPING.get()) {
-                if (SpellKeybind.IS_ON_SECONd_HOTBAR) {
-                    if (number > -1) {
-                        number += 4;
-                    }
-                }
-            }
-
-            if (number > -1) {
-                // todo make sure its not lagging servers
-                Packets.sendToServer(new TellServerToCastSpellPacket(number));
-                cooldown = 2;
+    private static void checkToAddSpellKeyPress(SpellKeybind key) {
+        if (key.key.consumeClick()) {
+            spellKeysPressed.add(key);
+            // Consume any remaining clicks
+            while (key.key.consumeClick()) {
             }
         }
+    }
+
+    private static void updateSpellInputs() {
+        var keys = SpellKeybind.ALL;
+
+        if (ClientConfigs.getConfig().HOTBAR_SWAPPING.get()) {
+            keys = SpellKeybind.FIRST_HOTBAR_KEYS;
+        }
+
+        spellKeysPressed.removeIf(key -> !key.key.isDown());
+
+        // Prioritize binds with modifiers in case the same key is reused but with a modifier
+        for (SpellKeybind key : keys) {
+            if (key.key.getKeyModifier() == KeyModifier.NONE) {
+                checkToAddSpellKeyPress(key);
+            }
+        }
+
+        for (SpellKeybind key : keys) {
+            if (key.key.getKeyModifier() != KeyModifier.NONE) {
+                checkToAddSpellKeyPress(key);
+            }
+        }
+
+        int number;
+
+        if (!spellKeysPressed.empty()) {
+            number = spellKeysPressed.lastElement().getIndex();
+            if (SpellKeybind.IS_ON_SECONd_HOTBAR) {
+                number += 4;
+            }
+        } else {
+            number = -1;
+        }
+
+        if (number == lastSpellNumber) {
+            if (number == -1) {
+                return;
+            }
+            if (spellPacketResendTimer > 0) {
+                spellPacketResendTimer--;
+                return;
+            }
+        }
+
+        Packets.sendToServer(new TellServerToCastSpellPacket(number));
+        lastSpellNumber = number;
+        spellPacketResendTimer = 2;
     }
 }

--- a/src/main/java/com/robertx22/mine_and_slash/event_hooks/player/OnKeyPress.java
+++ b/src/main/java/com/robertx22/mine_and_slash/event_hooks/player/OnKeyPress.java
@@ -57,13 +57,15 @@ public class OnKeyPress {
         }
     }
 
-    private static void checkToAddSpellKeyPress(SpellKeybind key) {
+    private static boolean checkToAddSpellKeyPress(SpellKeybind key) {
         if (key.key.consumeClick()) {
             spellKeysPressed.add(key);
             // Consume any remaining clicks
             while (key.key.consumeClick()) {
             }
+            return true;
         }
+        return false;
     }
 
     private static void updateSpellInputs() {
@@ -78,13 +80,17 @@ public class OnKeyPress {
         // Prioritize binds with modifiers in case the same key is reused but with a modifier
         for (SpellKeybind key : keys) {
             if (key.key.getKeyModifier() == KeyModifier.NONE) {
-                checkToAddSpellKeyPress(key);
+                if (checkToAddSpellKeyPress(key)) {
+                    break;
+                }
             }
         }
 
         for (SpellKeybind key : keys) {
             if (key.key.getKeyModifier() != KeyModifier.NONE) {
-                checkToAddSpellKeyPress(key);
+                if (checkToAddSpellKeyPress(key)) {
+                    break;
+                }
             }
         }
 

--- a/src/main/java/com/robertx22/mine_and_slash/saveclasses/spells/SpellCastingData.java
+++ b/src/main/java/com/robertx22/mine_and_slash/saveclasses/spells/SpellCastingData.java
@@ -35,6 +35,8 @@ import net.minecraft.world.item.ItemStack;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -207,6 +209,16 @@ public class SpellCastingData {
         }
     }
 
+    private static class SpellInputBufferEntry {
+        public int number;
+        public int ticksLeft;
+
+        public SpellInputBufferEntry(int number) {
+            this.number = number;
+            this.ticksLeft = 5;
+        }
+    }
+
     public int castTickLeft = 0;
     public int castTicksDone = 0;
     public int spellTotalCastTicks = 0;
@@ -214,12 +226,17 @@ public class SpellCastingData {
     public Boolean casting = false;
     public ChargeData charges = new ChargeData();
 
+    // Spell inputs to continuously attempt
+    transient List<SpellInputBufferEntry> spellInputBuffer = new LinkedList<>();
     // The hotbar index of the spell key the client is holding
-    public int spellInputNumber = -1;
+    transient int spellInputNumber = -1;
     // How many ticks left without another packet before we stop casting
-    public int spellInputTimeoutTicks = 0;
+    transient int spellInputTimeoutTicks = 0;
 
     public void onSpellInputPressed(int number) {
+        if (number != -1 && number != spellInputNumber) {
+            spellInputBuffer.add(new SpellInputBufferEntry(number));
+        }
         spellInputNumber = number;
         spellInputTimeoutTicks = 8;
     }
@@ -272,6 +289,11 @@ public class SpellCastingData {
         return false;
     }
 
+    public boolean tryStartSpellCast(Player player, int number) {
+        Spell spell = Load.player(player).getSkillGemInventory().getHotbarGem(number).getSpell();
+        return tryStartSpellCast(player, spell);
+    }
+
     public void cancelCast(LivingEntity entity) {
         try {
             if (isCasting()) {
@@ -309,57 +331,78 @@ public class SpellCastingData {
 
     transient static Spell lastSpell = null;
 
+    private void processSpellInputs(Player player) {
+
+        if (spellInputTimeoutTicks > 0) {
+            spellInputTimeoutTicks--;
+        } else {
+            // client stopped responding, don't cast forever
+            spellInputNumber = -1;
+        }
+
+        // Prune input buffer
+        for (Iterator<SpellInputBufferEntry> iterator = spellInputBuffer.iterator(); iterator.hasNext(); ) {
+            if (iterator.next().ticksLeft-- == 0) {
+                iterator.remove();
+            }
+        }
+
+        // See if any buffered inputs succeed
+        for (Iterator<SpellInputBufferEntry> iterator = spellInputBuffer.iterator(); iterator.hasNext(); ) {
+            if (tryStartSpellCast(player, iterator.next().number)) {
+                iterator.remove();
+                return;
+            }
+        }
+
+        // If not, try held input
+        if (spellInputNumber != -1) {
+            tryStartSpellCast(player, spellInputNumber);
+        }
+    }
+
     public void onTimePass(LivingEntity entity) {
 
         if (entity instanceof ServerPlayer player) {
-            if (spellInputNumber != -1) {
-                if (spellInputTimeoutTicks > 0) {
-                    Spell spell = Load.player(player).getSkillGemInventory().getHotbarGem(spellInputNumber).getSpell();
-                    tryStartSpellCast(player, spell);
-                    spellInputTimeoutTicks--;
-                } else {
-                    // client stopped responding, don't cast forever
-                    spellInputNumber = -1;
-                }
-            }
+            processSpellInputs(player);
         }
 
         if (isCasting()) {
             try {
-                    Spell spell = this.calcSpell.getSpell();
+                Spell spell = this.calcSpell.getSpell();
 
-                    SpellCastContext ctx = new SpellCastContext(entity, castTicksDone, spell);
+                SpellCastContext ctx = new SpellCastContext(entity, castTicksDone, spell);
 
-                    if (spell != null && ExileDB.Spells()
-                            .isRegistered(spell)) {
-                        spell.onCastingTick(ctx);
-                    }
+                if (spell != null && ExileDB.Spells()
+                        .isRegistered(spell)) {
+                    spell.onCastingTick(ctx);
+                }
 
-                    tryCast(ctx);
+                tryCast(ctx);
 
-                    lastSpell = spell;
+                lastSpell = spell;
 
-                    castTickLeft--;
-                    castTicksDone++;
+                castTickLeft--;
+                castTicksDone++;
 
-                    if (castTickLeft < 0) {
+                if (castTickLeft < 0) {
 
-                        for (Map.Entry<String, ExileEffectInstanceData> en : ctx.data.statusEffects.exileMap.entrySet()) {
-                            ExileEffect eff = ExileDB.ExileEffects().get(en.getKey());
-                            if (eff.remove_on_spell_cast != null) {
-                                if (spell.config.tags.contains(eff.remove_on_spell_cast)) {
-                                    en.getValue().stacks--;
-                                }
+                    for (Map.Entry<String, ExileEffectInstanceData> en : ctx.data.statusEffects.exileMap.entrySet()) {
+                        ExileEffect eff = ExileDB.ExileEffects().get(en.getKey());
+                        if (eff.remove_on_spell_cast != null) {
+                            if (spell.config.tags.contains(eff.remove_on_spell_cast)) {
+                                en.getValue().stacks--;
                             }
                         }
-
-                        if (ctx.caster instanceof ServerPlayer p) {
-                            Load.Unit(ctx.caster).sync.setDirty();
-                            TellClientEntityCastingSpell.sendUpdates(PlayerAnimations.CastEnum.CAST_FINISH, p, ctx.spell);
-                        }
-
-                        this.calcSpell = null;
                     }
+
+                    if (ctx.caster instanceof ServerPlayer p) {
+                        Load.Unit(ctx.caster).sync.setDirty();
+                        TellClientEntityCastingSpell.sendUpdates(PlayerAnimations.CastEnum.CAST_FINISH, p, ctx.spell);
+                    }
+
+                    this.calcSpell = null;
+                }
             } catch (Exception e) {
                 e.printStackTrace();
                 this.cancelCast(entity);

--- a/src/main/java/com/robertx22/mine_and_slash/saveclasses/spells/SpellCastingData.java
+++ b/src/main/java/com/robertx22/mine_and_slash/saveclasses/spells/SpellCastingData.java
@@ -227,8 +227,13 @@ public class SpellCastingData {
     public boolean tryStartSpellCast(Player player, Spell spell) {
 
         var data = Load.player(player);
+        var cds = Load.Unit(player).getCooldowns();
 
         if (player.isBlocking() || player.swinging) {
+            return false;
+        }
+
+        if (cds.isOnCooldown("global_cooldown")) {
             return false;
         }
 
@@ -248,18 +253,17 @@ public class SpellCastingData {
                 setToCast(c);
                 spell.spendResources(c);
 
+                // Limit global cooldown to spell cooldown to allow rapid fire spells
+                int gcd = Math.min(GameBalanceConfig.get().GLOBAL_COOLDOWN_TICKS, spell.getCooldownTicks(c));
+                cds.setOnCooldown("global_cooldown", gcd);
+
                 data.playerDataSync.setDirty();
                 return true;
-            } else {
-
-                var cds = Load.Unit(player).getCooldowns();
-
-                if (!cds.isOnCooldown("spell_fail")) {
-                    cds.setOnCooldown("spell_fail", 40);
-                    if (can.answer != null) {
-                        if (Load.Unit(player).getLevel() < 15 || Load.player(player).config.isConfigEnabled(PlayerConfigData.Config.CAST_FAIL)) {
-                            player.sendSystemMessage(Chats.CAST_FAILED.locName().append(can.answer));
-                        }
+            } else if (!cds.isOnCooldown("spell_fail")) {
+                cds.setOnCooldown("spell_fail", 40);
+                if (can.answer != null) {
+                    if (Load.Unit(player).getLevel() < 15 || Load.player(player).config.isConfigEnabled(PlayerConfigData.Config.CAST_FAIL)) {
+                        player.sendSystemMessage(Chats.CAST_FAILED.locName().append(can.answer));
                     }
                 }
             }

--- a/src/main/java/com/robertx22/mine_and_slash/saveclasses/spells/SpellCastingData.java
+++ b/src/main/java/com/robertx22/mine_and_slash/saveclasses/spells/SpellCastingData.java
@@ -235,7 +235,10 @@ public class SpellCastingData {
 
     public void onSpellInputPressed(int number) {
         if (number != -1 && number != spellInputNumber) {
-            spellInputBuffer.add(new SpellInputBufferEntry(number));
+            // Cap size to prevent DoS
+            if (spellInputBuffer.size() < 10) {
+                spellInputBuffer.add(new SpellInputBufferEntry(number));
+            }
         }
         spellInputNumber = number;
         spellInputTimeoutTicks = 8;

--- a/src/main/java/com/robertx22/mine_and_slash/saveclasses/spells/SpellCastingData.java
+++ b/src/main/java/com/robertx22/mine_and_slash/saveclasses/spells/SpellCastingData.java
@@ -4,6 +4,7 @@ import com.robertx22.library_of_exile.main.Packets;
 import com.robertx22.library_of_exile.util.ExplainedResult;
 import com.robertx22.mine_and_slash.a_libraries.player_animations.PlayerAnimations;
 import com.robertx22.mine_and_slash.capability.entity.EntityData;
+import com.robertx22.mine_and_slash.capability.player.data.PlayerConfigData;
 import com.robertx22.mine_and_slash.config.forge.compat.CompatConfig;
 import com.robertx22.mine_and_slash.database.data.exile_effects.ExileEffect;
 import com.robertx22.mine_and_slash.database.data.exile_effects.ExileEffectInstanceData;
@@ -30,6 +31,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -212,6 +214,59 @@ public class SpellCastingData {
     public Boolean casting = false;
     public ChargeData charges = new ChargeData();
 
+    // The hotbar index of the spell key the client is holding
+    public int spellInputNumber = -1;
+    // How many ticks left without another packet before we stop casting
+    public int spellInputTimeoutTicks = 0;
+
+    public void onSpellInputPressed(int number) {
+        spellInputNumber = number;
+        spellInputTimeoutTicks = 8;
+    }
+
+    public boolean tryStartSpellCast(Player player, Spell spell) {
+
+        var data = Load.player(player);
+
+        if (player.isBlocking() || player.swinging) {
+            return false;
+        }
+
+        if (spell != null) {
+
+            var can = canCast(spell, player);
+
+            if (can.can) {
+
+                ItemStack wep = player.getMainHandItem();
+
+                if (!wep.isEmpty() && !RepairUtils.isItemBroken(wep)) {
+                    wep.hurt(1, player.getRandom(), (ServerPlayer) player);
+                }
+
+                SpellCastContext c = new SpellCastContext(player, 0, spell);
+                setToCast(c);
+                spell.spendResources(c);
+
+                data.playerDataSync.setDirty();
+                return true;
+            } else {
+
+                var cds = Load.Unit(player).getCooldowns();
+
+                if (!cds.isOnCooldown("spell_fail")) {
+                    cds.setOnCooldown("spell_fail", 40);
+                    if (can.answer != null) {
+                        if (Load.Unit(player).getLevel() < 15 || Load.player(player).config.isConfigEnabled(PlayerConfigData.Config.CAST_FAIL)) {
+                            player.sendSystemMessage(Chats.CAST_FAILED.locName().append(can.answer));
+                        }
+                    }
+                }
+            }
+
+        }
+        return false;
+    }
 
     public void cancelCast(LivingEntity entity) {
         try {
@@ -252,52 +307,62 @@ public class SpellCastingData {
 
     public void onTimePass(LivingEntity entity) {
 
-        try {
-
-            if (isCasting()) {
-                Spell spell = this.calcSpell.getSpell();
-
-                SpellCastContext ctx = new SpellCastContext(entity, castTicksDone, spell);
-
-                if (spell != null && ExileDB.Spells()
-                        .isRegistered(spell)) {
-                    spell.onCastingTick(ctx);
+        if (entity instanceof ServerPlayer player) {
+            if (spellInputNumber != -1) {
+                if (spellInputTimeoutTicks > 0) {
+                    Spell spell = Load.player(player).getSkillGemInventory().getHotbarGem(spellInputNumber).getSpell();
+                    tryStartSpellCast(player, spell);
+                    spellInputTimeoutTicks--;
+                } else {
+                    // client stopped responding, don't cast forever
+                    spellInputNumber = -1;
                 }
+            }
+        }
 
-                tryCast(ctx);
+        if (isCasting()) {
+            try {
+                    Spell spell = this.calcSpell.getSpell();
 
-                lastSpell = spell;
+                    SpellCastContext ctx = new SpellCastContext(entity, castTicksDone, spell);
 
-                castTickLeft--;
-                castTicksDone++;
+                    if (spell != null && ExileDB.Spells()
+                            .isRegistered(spell)) {
+                        spell.onCastingTick(ctx);
+                    }
 
-                if (castTickLeft < 0) {
+                    tryCast(ctx);
 
-                    for (Map.Entry<String, ExileEffectInstanceData> en : ctx.data.statusEffects.exileMap.entrySet()) {
-                        ExileEffect eff = ExileDB.ExileEffects().get(en.getKey());
-                        if (eff.remove_on_spell_cast != null) {
-                            if (spell.config.tags.contains(eff.remove_on_spell_cast)) {
-                                en.getValue().stacks--;
+                    lastSpell = spell;
+
+                    castTickLeft--;
+                    castTicksDone++;
+
+                    if (castTickLeft < 0) {
+
+                        for (Map.Entry<String, ExileEffectInstanceData> en : ctx.data.statusEffects.exileMap.entrySet()) {
+                            ExileEffect eff = ExileDB.ExileEffects().get(en.getKey());
+                            if (eff.remove_on_spell_cast != null) {
+                                if (spell.config.tags.contains(eff.remove_on_spell_cast)) {
+                                    en.getValue().stacks--;
+                                }
                             }
                         }
+
+                        if (ctx.caster instanceof ServerPlayer p) {
+                            Load.Unit(ctx.caster).sync.setDirty();
+                            TellClientEntityCastingSpell.sendUpdates(PlayerAnimations.CastEnum.CAST_FINISH, p, ctx.spell);
+                        }
+
+                        this.calcSpell = null;
                     }
-
-                    if (ctx.caster instanceof ServerPlayer p) {
-                        Load.Unit(ctx.caster).sync.setDirty();
-                        TellClientEntityCastingSpell.sendUpdates(PlayerAnimations.CastEnum.CAST_FINISH, p, ctx.spell);
-                    }
-
-                    this.calcSpell = null;
-                }
-            } else {
-
-                lastSpell = null;
+            } catch (Exception e) {
+                e.printStackTrace();
+                this.cancelCast(entity);
+                // cancel when error, cus this is called on tick, so it doesn't crash servers when 1 spell fails
             }
-
-        } catch (Exception e) {
-            e.printStackTrace();
-            this.cancelCast(entity);
-            // cancel when error, cus this is called on tick, so it doesn't crash servers when 1 spell fails
+        } else {
+            lastSpell = null;
         }
     }
 

--- a/src/main/java/com/robertx22/mine_and_slash/vanilla_mc/packets/spells/TellServerToCastSpellPacket.java
+++ b/src/main/java/com/robertx22/mine_and_slash/vanilla_mc/packets/spells/TellServerToCastSpellPacket.java
@@ -2,18 +2,10 @@ package com.robertx22.mine_and_slash.vanilla_mc.packets.spells;
 
 import com.robertx22.library_of_exile.main.MyPacket;
 import com.robertx22.library_of_exile.packets.ExilePacketContext;
-import com.robertx22.mine_and_slash.capability.player.data.PlayerConfigData;
-import com.robertx22.mine_and_slash.database.data.spells.components.Spell;
-import com.robertx22.mine_and_slash.database.data.spells.spell_classes.bases.SpellCastContext;
 import com.robertx22.mine_and_slash.mmorpg.SlashRef;
 import com.robertx22.mine_and_slash.uncommon.datasaving.Load;
-import com.robertx22.mine_and_slash.uncommon.localization.Chats;
-import com.robertx22.mine_and_slash.uncommon.utilityclasses.RepairUtils;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.ItemStack;
 
 public class TellServerToCastSpellPacket extends MyPacket<TellServerToCastSpellPacket> {
 
@@ -41,57 +33,9 @@ public class TellServerToCastSpellPacket extends MyPacket<TellServerToCastSpellP
         tag.writeInt(number);
     }
 
-    public static boolean tryCastSpell(Player player, Spell spell) {
-
-        var data = Load.player(player);
-
-        if (player.isBlocking() || player.swinging) {
-            return false;
-        }
-
-        if (spell != null) {
-
-            var can = data.spellCastingData.canCast(spell, player);
-
-            if (can.can) {
-
-                ItemStack wep = player.getMainHandItem();
-
-                if (!wep.isEmpty() && !RepairUtils.isItemBroken(wep)) {
-                    wep.hurt(1, player.getRandom(), (ServerPlayer) player);
-                }
-
-                SpellCastContext c = new SpellCastContext(player, 0, spell);
-                data.spellCastingData.setToCast(c);
-                spell.spendResources(c);
-
-                data.playerDataSync.setDirty();
-                return true;
-            } else {
-
-                var cds = Load.Unit(player).getCooldowns();
-
-                if (!cds.isOnCooldown("spell_fail")) {
-                    cds.setOnCooldown("spell_fail", 40);
-                    if (can.answer != null) {
-                        if (Load.Unit(player).getLevel() < 15 || Load.player(player).config.isConfigEnabled(PlayerConfigData.Config.CAST_FAIL)) {
-                            player.sendSystemMessage(Chats.CAST_FAILED.locName().append(can.answer));
-                        }
-                    }
-                }
-            }
-
-        }
-        return false;
-    }
-
     @Override
     public void onReceived(ExilePacketContext ctx) {
-        Player player = ctx.getPlayer();
-
-        Spell spell = Load.player(ctx.getPlayer()).getSkillGemInventory().getHotbarGem(number).getSpell();
-
-        tryCastSpell(player, spell);
+        Load.player(ctx.getPlayer()).spellCastingData.onSpellInputPressed(number);
 
     }
 


### PR DESCRIPTION
* Prioritize the most recently pressed spell input instead of highest index
* Always send a packet when the spell input changes, only use rate limit for resending the same spell input
* Client now explicitly sends a -1 spell packet when no longer trying to cast, otherwise assume the client wants to keep casting the same spell ASAP for up to 8 ticks since the last packet (consistent DPS and each tick of cooldown reduction always matters)
* The clientside cooldown between spell inputs has been replaced with a configurable global cooldown defaulting to 3 ticks (capped to the cooldown of the spell that was cast)
* Spell inputs now have a 5 tick buffer so your inputs don't get eaten