### PR TITLE
fix discontinuous cast

### DIFF
--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/Spell.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/Spell.java
@@ -157,28 +157,29 @@ public final class Spell implements ISkillGem, IGUID, IAutoGson<Spell>, JsonExil
     }
 
     public final void onCastingTick(SpellCastContext ctx) {
-        int timesToCast = (int) ctx.spell.getConfig().times_to_cast;
-        if (timesToCast > 1) {
-            int castTimeTicks = (int) getCastTimeTicks(ctx);
+
+        int timesToCast = ctx.spell.getConfig().times_to_cast;
+        if (timesToCast > 1){
+            SpellCastInfo castInfo = getCastInfo(ctx);
+
             // if i didnt do this then cast time reduction would reduce amount of spell hits.
-            int castEveryXTicks = castTimeTicks / timesToCast;
-            if (timesToCast > 1) {
-                if (castEveryXTicks < 1) {
-                    castEveryXTicks = 1;
-                }
-            }
-            if (ctx.ticksInUse > 0 && ctx.ticksInUse % castEveryXTicks == 0) {
+
+
+            if (ctx.ticksInUse > 0 && castInfo.castInThisTick(ctx.ticksInUse)) {
                 this.cast(ctx);
             }
+
         } else if (timesToCast < 1) {
             ExileLog.get().warn("Times to cast spell is: " + timesToCast + " . this seems like a bug.");
         }
+
+        ctx.castedThisTick = true;
     }
 
     public void cast(SpellCastContext ctx) {
         LivingEntity caster = ctx.caster;
-        ctx.castedThisTick = true;
-        /*
+
+     /*
         if (MMORPG.RUN_DEV_TOOLS_REMOVE_WHEN_DONE && this.config.swing_arm) {
             //    caster.swingTime = -1; // this makes sure hand swings
             //   caster.swing(InteractionHand.MAIN_HAND);
@@ -195,9 +196,32 @@ public final class Spell implements ISkillGem, IGUID, IAutoGson<Spell>, JsonExil
         return (int) ctx.event.data.getNumber(EventData.CHARGE_COOLDOWN_TICKS).number;
     }
 
-    public final int getCastTimeTicks(SpellCastContext ctx) {
+    public SpellCastInfo getCastInfo(SpellCastContext ctx) {
         // if it casts 5 times a cast, it should take at least 5 ticks to cast it
-        return MathHelper.clamp((int) ctx.event.data.getNumber(EventData.CAST_TICKS).number, config.times_to_cast, 10000);
+        // since Robert don't want spell can be cast multiple times in a single tick, then we have to handle the decimal cast tick carefully
+        float clamp = MathHelper.clamp(ctx.event.data.getNumber(EventData.CAST_TICKS).number, config.times_to_cast * 1f, 10000f);
+        int timesToCast = ctx.spell.getConfig().times_to_cast;
+        float singleTimeCost = clamp / timesToCast;
+        int[] points = new int[timesToCast];
+        //means a single cast cost decimal tick
+        if (singleTimeCost % 1 != 0) {
+            for (int i = 0; i < timesToCast; i++) {
+                float v = singleTimeCost * (i + 1);
+                //means the result time is integer at some situation, like 2.5 * 4 ticks.
+                if (v % 1 == 0){
+                    points[i] = ((int) v);
+                } else {
+                    points[i] = ((int) Math.ceil(singleTimeCost * (i + 1)));
+                }
+
+            }
+        } else {
+            for (int i = 0; i < timesToCast; i++) {
+                points[i] = ((int) singleTimeCost) * (i + 1);
+            }
+
+        }
+        return new SpellCastInfo(points[points.length - 1], points);
     }
 
     @Override
@@ -272,12 +296,12 @@ public final class Spell implements ISkillGem, IGUID, IAutoGson<Spell>, JsonExil
             list.add(Words.COOLDOWN.locName(getCooldownTicks(ctx) / 20).withStyle(ChatFormatting.YELLOW));
         }
 
-        int casttime = getCastTimeTicks(ctx);
+        int casttime = getCastInfo(ctx).castTime();
 
         if (casttime == 0) {
             list.add(Words.INSTANT_CAST.locName().withStyle(ChatFormatting.GREEN));
         } else {
-            list.add(Words.CAST_TIME.locName(casttime / 20).withStyle(ChatFormatting.GREEN));
+            list.add(Words.CAST_TIME.locName(Math.round(casttime / 20.0f * 100f) / 100f).withStyle(ChatFormatting.GREEN));
         }
 
         Set<String> radiuses = new LinkedHashSet<>();

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/SpellCastInfo.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/SpellCastInfo.java
@@ -1,0 +1,14 @@
+package com.robertx22.mine_and_slash.database.data.spells.components;
+
+import java.util.TreeSet;
+
+public record SpellCastInfo(int castTime, int[] castPoint) {
+
+    //for quick search
+    public boolean castInThisTick( int target) {
+        for (int n : castPoint) {
+            if (n == target) return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/robertx22/mine_and_slash/saveclasses/spells/SpellCastingData.java
+++ b/src/main/java/com/robertx22/mine_and_slash/saveclasses/spells/SpellCastingData.java
@@ -13,7 +13,6 @@ import com.robertx22.mine_and_slash.database.data.spells.components.Spell;
 import com.robertx22.mine_and_slash.database.data.spells.entities.CalculatedSpellData;
 import com.robertx22.mine_and_slash.database.data.spells.spell_classes.CastingWeapon;
 import com.robertx22.mine_and_slash.database.data.spells.spell_classes.bases.SpellCastContext;
-import com.robertx22.mine_and_slash.database.data.spells.spell_classes.bases.SpellPredicates;
 import com.robertx22.mine_and_slash.database.data.stats.types.LearnSpellStat;
 import com.robertx22.mine_and_slash.database.data.stats.types.MaxAllSpellLevels;
 import com.robertx22.mine_and_slash.database.data.stats.types.MaxSpellLevel;
@@ -427,7 +426,8 @@ public class SpellCastingData {
     public void setToCast(SpellCastContext ctx) {
 
         this.calcSpell = ctx.calcData;
-        this.castTickLeft = ctx.spell.getCastTimeTicks(ctx);
+
+        this.castTickLeft = ctx.spell.getCastInfo(ctx).castTime();
         this.spellTotalCastTicks = this.castTickLeft;
         this.castTicksDone = 0;
         this.casting = true;

--- a/src/main/java/com/robertx22/mine_and_slash/uncommon/effectdatas/rework/action/DecreaseNumberByPercentEffect.java
+++ b/src/main/java/com/robertx22/mine_and_slash/uncommon/effectdatas/rework/action/DecreaseNumberByPercentEffect.java
@@ -21,6 +21,7 @@ public class DecreaseNumberByPercentEffect extends StatEffect {
     @Override
     public void activate(EffectEvent event, EffectSides statSource, StatData data, Stat stat) {
         event.data.getNumber(num_id).number -= event.data.getOriginalNumber(num_id).number * data.getValue() / 100F;
+        event.data.getNumber(num_id).number = Math.round(event.data.getNumber(num_id).number * 100.0f) / 100.0f;
     }
 
     @Override


### PR DESCRIPTION
Fix an issue where some casts will be canceled when the cast speed is too high.
This PR allows spells to do multiple casts in a single tick to avoid the problem.
